### PR TITLE
[NO-ISSUE] refactor: hide reminder job behind an env var/flag

### DIFF
--- a/scheduler/crates/api/src/lib.rs
+++ b/scheduler/crates/api/src/lib.rs
@@ -56,7 +56,7 @@ impl Application {
 
     fn start_job_schedulers(context: NettuContext) {
         if let Ok(reminders_job_enabled) = std::env::var("REMINDERS_JOB_ENABLED") {
-            // Parse the value of REMINDER_JOB_ENABLED to a boolean
+            // Parse the value of REMINDERS_JOB_ENABLED to a boolean
             // If it fails, log a warning and default to false
             // Use shadowing as we don't need the original value anymore
             let reminders_job_enabled =

--- a/scheduler/crates/api/src/lib.rs
+++ b/scheduler/crates/api/src/lib.rs
@@ -55,19 +55,20 @@ impl Application {
     }
 
     fn start_job_schedulers(context: NettuContext) {
-        if let Ok(reminder_job_enabled) = std::env::var("REMINDER_JOB_ENABLED") {
+        if let Ok(reminders_job_enabled) = std::env::var("REMINDERS_JOB_ENABLED") {
             // Parse the value of REMINDER_JOB_ENABLED to a boolean
             // If it fails, log a warning and default to false
             // Use shadowing as we don't need the original value anymore
-            let reminder_job_enabled = reminder_job_enabled.parse::<bool>().unwrap_or_else(|_| {
-                warn!(
-                    "Invalid value for BACKEND_JOB_ENABLED ({}). Defaulting to false.",
-                    reminder_job_enabled
-                );
-                false
-            });
+            let reminders_job_enabled =
+                reminders_job_enabled.parse::<bool>().unwrap_or_else(|_| {
+                    warn!(
+                        "Invalid value for BACKEND_JOB_ENABLED ({}). Defaulting to false.",
+                        reminders_job_enabled
+                    );
+                    false
+                });
 
-            if reminder_job_enabled {
+            if reminders_job_enabled {
                 start_send_reminders_job(context.clone());
                 start_reminder_generation_job_scheduler(context);
             }

--- a/scheduler/crates/api/src/lib.rs
+++ b/scheduler/crates/api/src/lib.rs
@@ -55,14 +55,14 @@ impl Application {
     }
 
     fn start_job_schedulers(context: NettuContext) {
-        if let Ok(reminders_job_enabled) = std::env::var("REMINDERS_JOB_ENABLED") {
-            // Parse the value of REMINDERS_JOB_ENABLED to a boolean
+        if let Ok(reminders_job_enabled) = std::env::var("NITTEI_REMINDERS_JOB_ENABLED") {
+            // Parse the value of NITTEI_REMINDERS_JOB_ENABLED to a boolean
             // If it fails, log a warning and default to false
             // Use shadowing as we don't need the original value anymore
             let reminders_job_enabled =
                 reminders_job_enabled.parse::<bool>().unwrap_or_else(|_| {
                     warn!(
-                        "Invalid value for BACKEND_JOB_ENABLED ({}). Defaulting to false.",
+                        "Invalid value for NITTEI_REMINDERS_JOB_ENABLED ({}). Defaulting to false.",
                         reminders_job_enabled
                     );
                     false


### PR DESCRIPTION
### Changed
- Hide the background job behind an environment variable

### Todo
- I'm thinking of extracting all env vars into one single file (like we do with `config` in Node) so that it's easy to see what are all env vars. Right now they are split into multiple files inside the code
  - Ongoing in  https://github.com/meetsmore/nittei/pull/6