### PR TITLE
[NO-ISSUE] fix(helm): allow all "envs" values + update chart version

### DIFF
--- a/charts/nittei/Chart.yaml
+++ b/charts/nittei/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -51,9 +51,10 @@ spec:
           {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env }}
           env:
-            - name: DATABASE_URL
-              value: {{ $database_url }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
       {{- with .Values.volumes }}
       volumes:

--- a/charts/nittei/values.yaml
+++ b/charts/nittei/values.yaml
@@ -10,8 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-env:
-  DATABASE_URL: ""
+env: []
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
### Changed
- Allow all "envs" config in the Helm chart
- Upgrade Helm chart so that we can make a new release