### PR TITLE
[NO-ISSUE] fix: remove database_url check in chart

### DIFF
--- a/charts/nittei/Chart.yaml
+++ b/charts/nittei/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -1,5 +1,3 @@
-{{- $database_url := .Values.DATABASE_URL | required ".Values.DATABASE_URL is required." -}}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
### Changed
- Remove check on DATABASE_URL
  - We allow all envs now (https://github.com/meetsmore/nittei/pull/34)
    - TODO (later): add explaantion of expected env vars in chart's folder and in values.yml
- Update chart version for triggering new deployment 