### PR TITLE
[NO-ISSUE] feat: run migrations at startup

### DIFF
--- a/scheduler/crates/infra/src/repos/mod.rs
+++ b/scheduler/crates/infra/src/repos/mod.rs
@@ -73,8 +73,16 @@ impl Repos {
             .connect(connection_string)
             .await
             .expect("TO CONNECT TO POSTGRES");
-
         info!("DB CHECKING CONNECTION ... [done]");
+
+        if std::env::var("NETTU_SKIP_MIGRATION").is_err() {
+            info!("DB EXECUTING MIGRATION ...");
+            sqlx::migrate!().run(&pool).await?;
+            info!("DB EXECUTING MIGRATION ... [done]");
+        } else {
+            info!("DB MIGRATION SKIPPED");
+        }
+
         Ok(Self {
             accounts: Arc::new(PostgresAccountRepo::new(pool.clone())),
             account_integrations: Arc::new(PostgresAccountIntegrationRepo::new(pool.clone())),


### PR DESCRIPTION
### Changed
- By default, execute the DB migrations at startup
  - Add env var to skip if needed