### PR TITLE
[NO-ISSUE] fix: allow to bind other host with env var

### DIFF
--- a/scheduler/crates/api/src/lib.rs
+++ b/scheduler/crates/api/src/lib.rs
@@ -23,7 +23,7 @@ use nettu_scheduler_domain::{
     ID,
 };
 use nettu_scheduler_infra::NettuContext;
-use tracing::warn;
+use tracing::{info, warn};
 use tracing_actix_web::TracingLogger;
 
 pub fn configure_server_api(cfg: &mut web::ServiceConfig) {
@@ -82,8 +82,10 @@ impl Application {
 
     async fn configure_server(context: NettuContext) -> Result<(Server, u16), std::io::Error> {
         let port = context.config.port;
-        let address = format!("127.0.0.1:{}", port);
-        let listener = TcpListener::bind(address)?;
+        let address = std::env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+        let address_and_port = format!("{}:{}", address, port);
+        info!("Starting server on: {}", address_and_port);
+        let listener = TcpListener::bind(address_and_port)?;
         let port = listener.local_addr().unwrap().port();
 
         let server = HttpServer::new(move || {

--- a/scheduler/crates/api/src/lib.rs
+++ b/scheduler/crates/api/src/lib.rs
@@ -82,7 +82,7 @@ impl Application {
 
     async fn configure_server(context: NettuContext) -> Result<(Server, u16), std::io::Error> {
         let port = context.config.port;
-        let address = std::env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+        let address = std::env::var("NITTEI_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
         let address_and_port = format!("{}:{}", address, port);
         info!("Starting server on: {}", address_and_port);
         let listener = TcpListener::bind(address_and_port)?;

--- a/scheduler/crates/infra/src/config.rs
+++ b/scheduler/crates/infra/src/config.rs
@@ -34,7 +34,7 @@ impl Config {
             }
         };
         let default_port = "5000";
-        let port = std::env::var("PORT").unwrap_or_else(|_| default_port.into());
+        let port = std::env::var("NITTEI_PORT").unwrap_or_else(|_| default_port.into());
         let port = match port.parse::<usize>() {
             Ok(port) => port,
             Err(_) => {


### PR DESCRIPTION
### Changed
- Allow to specify host address to be bound via env var (127.0.0.1 is default, but we want 0.0.0.0 when deployed)
  - `NITTEI_HOST`
- Rename env var `PORT` to `NITTEI_PORT` 