### PR TITLE
chore: remove nextest config

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       PORT: 5000
       DATABASE_URL: postgresql://postgres:postgres@localhost/nettuscheduler
+      RUST_BACKTRACE: 1
 
     steps:
       - name: Checkout repository
@@ -88,4 +89,4 @@ jobs:
       - name: Run server tests
         run: |
           cd scheduler
-          cargo nextest run --workspace
+          cargo run test --workspace

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -89,4 +89,4 @@ jobs:
       - name: Run server tests
         run: |
           cd scheduler
-          cargo run test --workspace
+          cargo test --workspace

--- a/scheduler/.config/nextest.toml
+++ b/scheduler/.config/nextest.toml
@@ -1,8 +1,0 @@
-# Test group for running some tests serially
-[test-groups]
-serial-integration = { max-threads = 1 }
-
-# Tests that contain `serial_` are run serially
-[[profile.default.overrides]]
-filter = 'test(serial_)'
-test-group = 'serial-integration'


### PR DESCRIPTION
### Changed
- Remove Nextest config
- Use `cargo test` directly in CI
  - Add `RUST_BACKTRACE` env var to force backtraces to be created