### PR TITLE
chore: add revisionHistoryLimit to chart

### DIFF
--- a/charts/nittei/Chart.yaml
+++ b/charts/nittei/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -70,3 +70,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/charts/nittei/values.yaml
+++ b/charts/nittei/values.yaml
@@ -114,3 +114,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+revisionHistoryLimit: 5


### PR DESCRIPTION
### Changed
- [chart] Add `revisionHistoryLimit` variable
  - Default to 5 (I believe it's 10 the "true" default value ?)