### PR TITLE
feat(js client): improve things (one axios client, keepAlive, baseUrl…

### DIFF
--- a/scheduler/clients/javascript/lib/helpers/credentials.ts
+++ b/scheduler/clients/javascript/lib/helpers/credentials.ts
@@ -1,0 +1,88 @@
+/**
+ * Partial credentials to be used for the client
+ */
+export type PartialCredentials = {
+  /**
+   * API key (admin)
+   */
+  apiKey?: string
+  /**
+   * Nettu account id (admin)
+   */
+  nettuAccount?: string
+  /**
+   * Token (user)
+   */
+  token?: string
+}
+
+/**
+ * Create credentials for the client (admin or user)
+ * @param creds partial credentials
+ * @returns credentials
+ */
+export const createCreds = (creds?: PartialCredentials): ICredentials => {
+  if (creds?.apiKey) {
+    return new AccountCreds(creds.apiKey)
+  }
+  if (creds?.nettuAccount) {
+    return new UserCreds(creds?.nettuAccount, creds?.token)
+  }
+  // throw new Error("No api key or nettu account provided to nettu client.");
+  return new EmptyCreds()
+}
+
+/**
+ * Credentials for the API for end users (usually frontend)
+ */
+export class UserCreds implements ICredentials {
+  private readonly nettuAccount: string
+  private readonly token?: string
+
+  constructor(nettuAccount: string, token?: string) {
+    this.nettuAccount = nettuAccount
+    this.token = token
+  }
+
+  createAuthHeaders() {
+    const creds: Record<string, string> = {
+      'nettu-account': this.nettuAccount,
+    }
+    if (this.token) {
+      creds.authorization = `Bearer ${this.token}`
+    }
+
+    return Object.freeze(creds)
+  }
+}
+
+/**
+ * Credentials for the API for admins (usually backend)
+ */
+export class AccountCreds implements ICredentials {
+  private readonly apiKey: string
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey
+  }
+
+  createAuthHeaders() {
+    return Object.freeze({
+      'x-api-key': this.apiKey,
+    })
+  }
+}
+
+export interface ICredentials {
+  createAuthHeaders(): object
+}
+
+export class EmptyCreds implements ICredentials {
+  createAuthHeaders() {
+    return Object.freeze({})
+  }
+}
+
+export interface ICredentials {
+  createAuthHeaders(): object
+}

--- a/scheduler/clients/javascript/lib/index.ts
+++ b/scheduler/clients/javascript/lib/index.ts
@@ -68,7 +68,7 @@ export const NettuUserClient = (
 
   // User clients should not keep the connection alive (usually on the frontend)
   const axiosClient = createAxiosInstanceFrontend(
-    { baseUrl: finalConfig.baseUrl, keepAlive: false },
+    { baseUrl: finalConfig.baseUrl },
     creds
   )
 

--- a/scheduler/clients/javascript/lib/index.ts
+++ b/scheduler/clients/javascript/lib/index.ts
@@ -1,13 +1,12 @@
 import { NettuAccountClient } from './accountClient'
 import {
-  AccountCreds,
-  EmptyCreds,
-  type ICredentials,
-  UserCreds,
+  createAxiosInstanceBackend,
+  createAxiosInstanceFrontend,
 } from './baseClient'
 import { NettuCalendarClient, NettuCalendarUserClient } from './calendarClient'
 import { NettuEventClient, NettuEventUserClient } from './eventClient'
 import { NettuHealthClient } from './healthClient'
+import { createCreds, PartialCredentials } from './helpers/credentials'
 import { NettuScheduleUserClient, NettuScheduleClient } from './scheduleClient'
 import { NettuServiceUserClient, NettuServiceClient } from './serviceClient'
 import {
@@ -16,12 +15,6 @@ import {
 } from './userClient'
 
 export * from './domain'
-
-type PartialCredentials = {
-  apiKey?: string
-  nettuAccount?: string
-  token?: string
-}
 
 export interface INettuUserClient {
   calendar: NettuCalendarUserClient
@@ -41,51 +34,77 @@ export interface INettuClient {
   user: _NettuUserClient
 }
 
+/**
+ * Base configuration for the client
+ */
 type ClientConfig = {
-  baseUrl: string
+  /**
+   * Base URL for the API
+   */
+  baseUrl?: string
+
+  /**
+   * Keep the connection alive
+   */
+  keepAlive?: boolean
 }
 
-export const config: ClientConfig = {
+const DEFAULT_CONFIG: Required<ClientConfig> = {
   baseUrl: 'http://localhost:5000/api/v1',
+  keepAlive: false,
 }
 
+/**
+ * Create a client for the Nettu API (user client, not admin)
+ * @param config configuration and credentials to be used
+ * @returns user client
+ */
 export const NettuUserClient = (
-  partialCreds?: PartialCredentials
+  config?: PartialCredentials & ClientConfig
 ): INettuUserClient => {
-  const creds = createCreds(partialCreds)
+  const creds = createCreds(config)
+
+  const finalConfig = { ...DEFAULT_CONFIG, ...config }
+
+  // User clients should not keep the connection alive (usually on the frontend)
+  const axiosClient = createAxiosInstanceFrontend(
+    { baseUrl: finalConfig.baseUrl, keepAlive: false },
+    creds
+  )
 
   return Object.freeze({
-    calendar: new NettuCalendarUserClient(creds),
-    events: new NettuEventUserClient(creds),
-    service: new NettuServiceUserClient(creds),
-    schedule: new NettuScheduleUserClient(creds),
-    user: new NettuUserUserClient(creds),
+    calendar: new NettuCalendarUserClient(axiosClient),
+    events: new NettuEventUserClient(axiosClient),
+    service: new NettuServiceUserClient(axiosClient),
+    schedule: new NettuScheduleUserClient(axiosClient),
+    user: new NettuUserUserClient(axiosClient),
   })
 }
 
-export const NettuClient = (
-  partialCreds?: PartialCredentials
-): INettuClient => {
-  const creds = createCreds(partialCreds)
+/**
+ * Create a client for the Nettu API (admin client)
+ * @param config configuration and credentials to be used
+ * @returns admin client
+ */
+export const NettuClient = async (
+  config?: PartialCredentials & ClientConfig
+): Promise<INettuClient> => {
+  const creds = createCreds(config)
+
+  const finalConfig = { ...DEFAULT_CONFIG, ...config }
+
+  const axiosClient = await createAxiosInstanceBackend(
+    { baseUrl: finalConfig.baseUrl, keepAlive: finalConfig.keepAlive },
+    creds
+  )
 
   return Object.freeze({
-    account: new NettuAccountClient(creds),
-    events: new NettuEventClient(creds),
-    calendar: new NettuCalendarClient(creds),
-    user: new _NettuUserClient(creds),
-    service: new NettuServiceClient(creds),
-    schedule: new NettuScheduleClient(creds),
-    health: new NettuHealthClient(creds),
+    account: new NettuAccountClient(axiosClient),
+    events: new NettuEventClient(axiosClient),
+    calendar: new NettuCalendarClient(axiosClient),
+    user: new _NettuUserClient(axiosClient),
+    service: new NettuServiceClient(axiosClient),
+    schedule: new NettuScheduleClient(axiosClient),
+    health: new NettuHealthClient(axiosClient),
   })
-}
-
-const createCreds = (creds?: PartialCredentials): ICredentials => {
-  if (creds?.apiKey) {
-    return new AccountCreds(creds.apiKey)
-  }
-  if (creds?.nettuAccount) {
-    return new UserCreds(creds?.nettuAccount, creds?.token)
-  }
-  // throw new Error("No api key or nettu account provided to nettu client.");
-  return new EmptyCreds()
 }

--- a/scheduler/clients/javascript/lib/userClient.ts
+++ b/scheduler/clients/javascript/lib/userClient.ts
@@ -194,12 +194,12 @@ export class NettuUserClient extends NettuBaseClient {
       status: res.status,
       data: {
         events: res.data.events.map(event => {
-        return {
-          event: convertEventDates(event.event),
-          instances: event.instances.map(convertInstanceDates),
-        }
-      }),
-    }
+          return {
+            event: convertEventDates(event.event),
+            instances: event.instances.map(convertInstanceDates),
+          }
+        }),
+      },
     }
   }
 
@@ -232,14 +232,11 @@ export class NettuUserClient extends NettuBaseClient {
   public async freebusyMultipleUsers(
     req: GetMultipleUsersFeebusyReq
   ): Promise<APIResponse<GetUserFeebusyResponse>> {
-    const res = await this.post<GetUserFeebusyResponse>(
-      '/user/freebusy',
-      {
-        userIds: req.userIds,
-        startTime: req.startTime.toISOString(),
-        endTime: req.endTime.toISOString(),
-      }
-    )
+    const res = await this.post<GetUserFeebusyResponse>('/user/freebusy', {
+      userIds: req.userIds,
+      startTime: req.startTime.toISOString(),
+      endTime: req.endTime.toISOString(),
+    })
 
     if (!res.data) {
       return res

--- a/scheduler/clients/javascript/tests/account.spec.ts
+++ b/scheduler/clients/javascript/tests/account.spec.ts
@@ -1,4 +1,4 @@
-import { NettuClient } from '../lib'
+import { INettuClient, NettuClient } from '../lib'
 import {
   setupAccount,
   setupUserClientForAccount,
@@ -7,9 +7,10 @@ import {
 import { readPrivateKey, readPublicKey } from './helpers/utils'
 
 describe('Account API', () => {
-  const client = NettuClient()
+  let client: INettuClient
 
   it('should create account', async () => {
+    client = await NettuClient({})
     const { status, data } = await client.account.create({
       code: CREATE_ACCOUNT_CODE,
     })
@@ -24,7 +25,9 @@ describe('Account API', () => {
     if (!data) {
       throw new Error('Account not created')
     }
-    const accountClient = NettuClient({ apiKey: data.secretApiKey })
+    const accountClient = await NettuClient({
+      apiKey: data.secretApiKey,
+    })
     const res = await accountClient.account.me()
     expect(res.status).toBe(200)
     if (!res.data) {

--- a/scheduler/clients/javascript/tests/calendar.spec.ts
+++ b/scheduler/clients/javascript/tests/calendar.spec.ts
@@ -1,17 +1,13 @@
-import {
-  INettuClient,
-  NettuClient,
-  config,
-  type INettuUserClient,
-} from '../lib'
+import { INettuClient, NettuClient, type INettuUserClient } from '../lib'
 import { setupUserClient } from './helpers/fixtures'
 
 describe('Calendar API', () => {
   let client: INettuUserClient
   let userId: string
-  const unauthClient = NettuClient()
+  let unauthClient: INettuClient
 
   beforeAll(async () => {
+    unauthClient = await NettuClient({})
     const data = await setupUserClient()
     client = data.userClient
     userId = data.userId

--- a/scheduler/clients/javascript/tests/calendarEvent.spec.ts
+++ b/scheduler/clients/javascript/tests/calendarEvent.spec.ts
@@ -14,7 +14,9 @@ describe('CalendarEvent API', () => {
   beforeAll(async () => {
     const data = await setupUserClient()
     client = data.userClient
-    unauthClient = NettuClient({ nettuAccount: data.accountId })
+    unauthClient = await NettuClient({
+      nettuAccount: data.accountId,
+    })
     const calendarRes = await client.calendar.create({
       timezone: 'UTC',
     })

--- a/scheduler/clients/javascript/tests/health.spec.ts
+++ b/scheduler/clients/javascript/tests/health.spec.ts
@@ -1,9 +1,8 @@
 import { NettuClient } from '../lib'
 
 describe('Health API', () => {
-  const client = NettuClient()
-
   it('should report healthy status', async () => {
+    const client = await NettuClient({})
     const status = await client.health.checkStatus()
     expect(status).toBe(200)
   })

--- a/scheduler/clients/javascript/tests/helpers/fixtures.ts
+++ b/scheduler/clients/javascript/tests/helpers/fixtures.ts
@@ -6,14 +6,16 @@ export const CREATE_ACCOUNT_CODE =
   process.env.CREATE_ACCOUNT_SECRET_CODE || 'opqI5r3e7v1z2h3P'
 
 export const setupAccount = async () => {
-  const client = NettuClient()
+  const client = await NettuClient()
   const account = await client.account.create({ code: CREATE_ACCOUNT_CODE })
   const accountId = account.data?.account.id
   if (!accountId) {
     throw new Error('Account not created')
   }
   return {
-    client: NettuClient({ apiKey: account.data?.secretApiKey }),
+    client: await NettuClient({
+      apiKey: account.data?.secretApiKey,
+    }),
     accountId: account.data?.account.id,
   }
 }
@@ -62,7 +64,10 @@ export const setupUserClientForAccount = (
   )
   return {
     token,
-    client: NettuUserClient({ token, nettuAccount: accountId }),
+    client: NettuUserClient({
+      token,
+      nettuAccount: accountId,
+    }),
   }
 }
 

--- a/scheduler/clients/javascript/tests/requirements/requirements.spec.ts
+++ b/scheduler/clients/javascript/tests/requirements/requirements.spec.ts
@@ -878,7 +878,10 @@ describe('Requirements', () => {
         expect(res?.status).toBe(200)
         expect(res?.data).toBeDefined()
         expect(res?.data?.events.length).toBe(1)
-        console.log('res?.data?.events[0].event.startTime', res?.data?.events[0].event.startTime)
+        console.log(
+          'res?.data?.events[0].event.startTime',
+          res?.data?.events[0].event.startTime
+        )
         expect(res?.data?.events[0].event.startTime).toEqual(date1.toDate())
       })
 

--- a/scheduler/clients/javascript/tests/schedule.spec.ts
+++ b/scheduler/clients/javascript/tests/schedule.spec.ts
@@ -1,4 +1,5 @@
 import {
+  INettuClient,
   type INettuUserClient,
   NettuClient,
   ScheduleRuleVariant,
@@ -8,10 +9,11 @@ import { setupUserClient } from './helpers/fixtures'
 
 describe('Schedule API', () => {
   let client: INettuUserClient
-  const unauthClient = NettuClient()
+  let unauthClient: INettuClient
   let userId: string
 
   beforeAll(async () => {
+    unauthClient = await NettuClient({})
     const data = await setupUserClient()
     client = data.userClient
     userId = data.userId

--- a/scheduler/clients/javascript/tests/service.spec.ts
+++ b/scheduler/clients/javascript/tests/service.spec.ts
@@ -4,7 +4,7 @@ import {
   ScheduleRuleVariant,
   Weekday,
 } from '../lib'
-import { setupAccount, setupUserClient } from './helpers/fixtures'
+import { setupUserClient } from './helpers/fixtures'
 
 describe('Service API', () => {
   let client: INettuClient

--- a/scheduler/clients/javascript/tests/user.spec.ts
+++ b/scheduler/clients/javascript/tests/user.spec.ts
@@ -13,12 +13,15 @@ describe('User API', () => {
   let accountClient: INettuClient
   let client: INettuUserClient
   let unauthClient: INettuClient
+
   beforeAll(async () => {
     const data = await setupUserClient()
     client = data.userClient
     accountClient = data.accountClient
     userId = data.userId
-    unauthClient = NettuClient({ nettuAccount: data.accountId })
+    unauthClient = await NettuClient({
+      nettuAccount: data.accountId,
+    })
     const calendarRes = await client.calendar.create({ timezone: 'UTC' })
     if (!calendarRes.data) {
       throw new Error('Calendar not created')


### PR DESCRIPTION
### Changed
- Refactor client lib so that
  -  `baseUrl` can be provided in the parameter of the function creating a new Client
    - Use it in the Axios instance's configuration so that it doesn't need to be passed later
  - Make it so that only one Axios instance is created per client, instead of one per "subclass"
    - This means in most cases, only 1
  - For the admin client, allow to have `keepAlive` connections