### PR TITLE
refactor/improve error handling

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ export RUST_BACKTRACE := "1"
 install_tools: 
 	cargo install sqlx-cli
 	cargo install cargo-pretty-test
+	cargo install cargo-watch
 
 # Install all tools
 install_all_tools: install_tools
@@ -26,7 +27,7 @@ _setup_client_node:
 
 # Dev
 dev: _setup_db
-	cd scheduler && cargo run
+	cd scheduler && cargo watch -- cargo run
 
 # Prepare offline SQLx
 prepare_sqlx:

--- a/scheduler/.sqlx/query-1e438d5dacbdaec4fb616dcbcbb31ae31b4a847cbdaf2b7995103e6f2923da7a.json
+++ b/scheduler/.sqlx/query-1e438d5dacbdaec4fb616dcbcbb31ae31b4a847cbdaf2b7995103e6f2923da7a.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT s.*, u.account_uid FROM schedules AS s\n            INNER JOIN users AS u\n                ON u.user_uid = s.user_uid\n            WHERE s.schedule_uid = ANY($1)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "schedule_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "rules",
+        "type_info": "Json"
+      },
+      {
+        "ordinal": 3,
+        "name": "timezone",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 5,
+        "name": "account_uid",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1e438d5dacbdaec4fb616dcbcbb31ae31b4a847cbdaf2b7995103e6f2923da7a"
+}

--- a/scheduler/.sqlx/query-a0de3aebf02766d0d00717faa9ce79e9e561e0aebe247b8678955162aaa0bbb0.json
+++ b/scheduler/.sqlx/query-a0de3aebf02766d0d00717faa9ce79e9e561e0aebe247b8678955162aaa0bbb0.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT s.*, jsonb_agg((su.*)) AS users FROM services AS s\n            LEFT JOIN service_users AS su\n            ON su.service_uid = s.service_uid\n            WHERE s.service_uid = $1\n            GROUP BY s.service_uid\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "service_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "account_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "multi_person",
+        "type_info": "Json"
+      },
+      {
+        "ordinal": 3,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "users",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "a0de3aebf02766d0d00717faa9ce79e9e561e0aebe247b8678955162aaa0bbb0"
+}

--- a/scheduler/.sqlx/query-f1e3bdff95603cbc3855b2db49085525ccc7aeb4ab87dd8f10c2d0b26d20d1e7.json
+++ b/scheduler/.sqlx/query-f1e3bdff95603cbc3855b2db49085525ccc7aeb4ab87dd8f10c2d0b26d20d1e7.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT users.user_uid, events.created FROM users LEFT JOIN (\n                SELECT DISTINCT ON (user_uid) user_uid, e.created\n                FROM calendar_events AS e\n                INNER JOIN calendars AS c\n                    ON c.calendar_uid = e.calendar_uid\n                WHERE service_uid = $1\n                ORDER BY user_uid, created DESC\n            ) AS events ON events.user_uid = users.user_uid\n            WHERE users.user_uid = ANY($2)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "created",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "f1e3bdff95603cbc3855b2db49085525ccc7aeb4ab87dd8f10c2d0b26d20d1e7"
+}

--- a/scheduler/.sqlx/query-fa9c71d7c78ea93dd35d0019993601a7d4a77756182a45647d381181eb0eafbd.json
+++ b/scheduler/.sqlx/query-fa9c71d7c78ea93dd35d0019993601a7d4a77756182a45647d381181eb0eafbd.json
@@ -1,0 +1,106 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT e.*, u.user_uid, account_uid FROM calendar_events AS e\n            INNER JOIN calendars AS c\n                ON c.calendar_uid = e.calendar_uid\n            INNER JOIN users AS u\n                ON u.user_uid = c.user_uid\n            WHERE e.event_uid = ANY($1)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "event_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "calendar_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "start_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "duration",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "end_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "busy",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "created",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 8,
+        "name": "recurrence",
+        "type_info": "Json"
+      },
+      {
+        "ordinal": 9,
+        "name": "exdates",
+        "type_info": "TimestamptzArray"
+      },
+      {
+        "ordinal": 10,
+        "name": "reminders",
+        "type_info": "Json"
+      },
+      {
+        "ordinal": 11,
+        "name": "service_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 12,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 13,
+        "name": "user_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "account_uid",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fa9c71d7c78ea93dd35d0019993601a7d4a77756182a45647d381181eb0eafbd"
+}

--- a/scheduler/Cargo.lock
+++ b/scheduler/Cargo.lock
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "async-stream"
@@ -1605,6 +1605,7 @@ name = "nettu_scheduler"
 version = "0.1.0"
 dependencies = [
  "actix-web",
+ "anyhow",
  "chrono",
  "chrono-tz",
  "nettu_scheduler_api",

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -22,6 +22,8 @@ nettu_scheduler_api = { path = "./crates/api" }
 nettu_scheduler_domain = { path = "./crates/domain" }
 nettu_scheduler_infra = { path = "./crates/infra" }
 
+anyhow = "1.0"
+
 actix-web = "4.8"
 
 tokio = { version = "1", features = ["full"] }

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -59,9 +59,13 @@ nettu_scheduler_sdk = { path = "./clients/rust" }
 unsafe_code = "forbid"
 
 [lints.clippy]
-print_stdout = "forbid"
-print_err = "forbid"
+print_stdout = "deny"
+print_err = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
 
 [workspace.lints.clippy]
-print_stdout = "forbid"
-print_err = "forbid"
+print_stdout = "deny"
+print_err = "deny"
+unwrap_used = "deny"
+expect_used = "deny"

--- a/scheduler/clippy.toml
+++ b/scheduler/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/scheduler/crates/api/Cargo.toml
+++ b/scheduler/crates/api/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1.42"
 rrule = "0.12.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 chrono-tz = "0.8.1"
-anyhow = "1.0.0"
+anyhow = "1.0"
 jsonwebtoken = "7"
 thiserror = "1.0"
 tracing = "0.1.25"

--- a/scheduler/crates/api/src/account/set_account_webhook.rs
+++ b/scheduler/crates/api/src/account/set_account_webhook.rs
@@ -90,7 +90,7 @@ mod tests {
     #[actix_web::main]
     #[test]
     async fn it_rejects_invalid_webhook_url() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let bad_uris = vec!["1", "", "test.zzcom", "test.com", "google.com"];
         for bad_uri in bad_uris {
             let mut use_case = SetAccountWebhookUseCase {
@@ -114,7 +114,7 @@ mod tests {
     #[actix_web::main]
     #[test]
     async fn it_accepts_valid_webhook_url() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let valid_uris = vec!["https://google.com", "https://google.com/v1/webhook"];
         for valid_uri in valid_uris {

--- a/scheduler/crates/api/src/calendar/get_calendar_events.rs
+++ b/scheduler/crates/api/src/calendar/get_calendar_events.rs
@@ -104,7 +104,12 @@ impl UseCase for GetCalendarEventsUseCase {
     const NAME: &'static str = "GetCalendarEvents";
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
-        let calendar = ctx.repos.calendars.find(&self.calendar_id).await;
+        let calendar = ctx
+            .repos
+            .calendars
+            .find(&self.calendar_id)
+            .await
+            .map_err(|_| UseCaseError::IntervalServerError)?;
 
         let timespan = TimeSpan::new(self.start_time, self.end_time);
         if timespan.greater_than(ctx.config.event_instances_query_duration_limit) {

--- a/scheduler/crates/api/src/calendar/get_calendars_by_meta.rs
+++ b/scheduler/crates/api/src/calendar/get_calendars_by_meta.rs
@@ -18,6 +18,11 @@ pub async fn get_calendars_by_meta_controller(
         limit: query_params.0.limit.unwrap_or(20),
         skip: query_params.0.skip.unwrap_or(0),
     };
-    let calendars = ctx.repos.calendars.find_by_metadata(query).await;
+    let calendars = ctx
+        .repos
+        .calendars
+        .find_by_metadata(query)
+        .await
+        .map_err(|_| NettuError::InternalError)?;
     Ok(HttpResponse::Ok().json(APIResponse::new(calendars)))
 }

--- a/scheduler/crates/api/src/calendar/update_calendar.rs
+++ b/scheduler/crates/api/src/calendar/update_calendar.rs
@@ -140,7 +140,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn it_update_settings_with_valid_wkst() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);

--- a/scheduler/crates/api/src/calendar/update_calendar.rs
+++ b/scheduler/crates/api/src/calendar/update_calendar.rs
@@ -98,7 +98,13 @@ impl UseCase for UpdateCalendarUseCase {
     const NAME: &'static str = "UpdateCalendar";
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
-        let mut calendar = match ctx.repos.calendars.find(&self.calendar_id).await {
+        let calendar = ctx
+            .repos
+            .calendars
+            .find(&self.calendar_id)
+            .await
+            .map_err(|_| UseCaseError::StorageError)?;
+        let mut calendar = match calendar {
             Some(cal) if cal.user_id == self.user.id => cal,
             _ => return Err(UseCaseError::CalendarNotFound),
         };
@@ -161,7 +167,13 @@ mod test {
         assert!(res.is_ok());
 
         // Check that calendar settings have been updated
-        let calendar = ctx.repos.calendars.find(&calendar.id).await.unwrap();
+        let calendar = ctx
+            .repos
+            .calendars
+            .find(&calendar.id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(calendar.settings.week_start, new_wkst);
     }
 }

--- a/scheduler/crates/api/src/event/create_event.rs
+++ b/scheduler/crates/api/src/event/create_event.rs
@@ -199,7 +199,7 @@ mod test {
     }
 
     async fn setup() -> TestContext {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);

--- a/scheduler/crates/api/src/event/create_event.rs
+++ b/scheduler/crates/api/src/event/create_event.rs
@@ -129,7 +129,13 @@ impl UseCase for CreateEventUseCase {
     const NAME: &'static str = "CreateEvent";
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
-        let calendar = match ctx.repos.calendars.find(&self.calendar_id).await {
+        let calendar = ctx
+            .repos
+            .calendars
+            .find(&self.calendar_id)
+            .await
+            .map_err(|_| UseCaseError::StorageError)?;
+        let calendar = match calendar {
             Some(calendar) if calendar.user_id == self.user.id => calendar,
             _ => return Err(UseCaseError::NotFound(self.calendar_id.clone())),
         };

--- a/scheduler/crates/api/src/event/get_events_by_meta.rs
+++ b/scheduler/crates/api/src/event/get_events_by_meta.rs
@@ -18,6 +18,11 @@ pub async fn get_events_by_meta_controller(
         limit: query_params.0.limit.unwrap_or(20),
         skip: query_params.0.skip.unwrap_or(0),
     };
-    let events = ctx.repos.events.find_by_metadata(query).await;
+    let events = ctx
+        .repos
+        .events
+        .find_by_metadata(query)
+        .await
+        .map_err(|_| NettuError::InternalError)?;
     Ok(HttpResponse::Ok().json(APIResponse::new(events)))
 }

--- a/scheduler/crates/api/src/event/get_upcoming_reminders.rs
+++ b/scheduler/crates/api/src/event/get_upcoming_reminders.rs
@@ -174,7 +174,8 @@ mod tests {
         ctx.repos
             .reminders
             .delete_all_before(DateTime::<Utc>::MAX_UTC)
-            .await;
+            .await
+            .unwrap();
 
         ctx
     }
@@ -185,7 +186,7 @@ mod tests {
             1613862000000 // Sun Feb 21 2021 00:00:00 GMT+0100 (Central European Standard Time) {}
         }
         fn get_timestamp(&self) -> DateTime<Utc> {
-            DateTime::<Utc>::from_timestamp_millis(1613862000).unwrap()
+            DateTime::from_timestamp_millis(1613862000000).unwrap()
         }
     }
 
@@ -195,7 +196,7 @@ mod tests {
             1613862000000 + 1000 * 60 * 49 // Sun Feb 21 2021 00:49:00 GMT+0100 (Central European Standard Time) {}
         }
         fn get_timestamp(&self) -> DateTime<Utc> {
-            DateTime::<Utc>::from_timestamp_millis(1613862000000 + 1000 * 60 * 49).unwrap()
+            DateTime::from_timestamp_millis(1613862000000 + 1000 * 60 * 49).unwrap()
         }
     }
 
@@ -205,7 +206,7 @@ mod tests {
             1613862000000 + 1000 * 60 * 60 * 24 // Sun Feb 22 2021 00:00:00 GMT+0100 (Central European Standard Time) {}
         }
         fn get_timestamp(&self) -> DateTime<Utc> {
-            DateTime::<Utc>::from_timestamp_millis(1613862000000 + 1000 * 60 * 60 * 24).unwrap()
+            DateTime::from_timestamp_millis(1613862000000 + 1000 * 60 * 60 * 24).unwrap()
         }
     }
 
@@ -233,7 +234,7 @@ mod tests {
         let usecase = CreateEventUseCase {
             user: user.clone(),
             calendar_id: calendar.id.clone(),
-            start_time: DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis()).unwrap(),
+            start_time: ctx.sys.get_timestamp(),
             duration: 1000 * 60 * 60 * 2,
             recurrence: Some(Default::default()),
             reminders: vec![
@@ -255,8 +256,7 @@ mod tests {
         let usecase = CreateEventUseCase {
             calendar_id: calendar.id.clone(),
             user,
-            start_time: DateTime::from_timestamp_millis(sys3.get_timestamp_millis()).unwrap()
-                + TimeDelta::milliseconds(1000 * 60 * 5),
+            start_time: sys3.get_timestamp() + TimeDelta::milliseconds(1000 * 60 * 5),
             duration: 1000 * 60 * 60 * 2,
             reminders: vec![CalendarEventReminder {
                 delta: -10,
@@ -312,9 +312,8 @@ mod tests {
         let mut ctx = setup_context().await;
         ctx.sys = Arc::new(StaticTimeSys1 {});
 
-        let now = ctx.sys.get_timestamp_millis();
-        let initial_start_time =
-            DateTime::from_timestamp_millis(now).unwrap() + TimeDelta::milliseconds(30 * 60 * 1000);
+        let now = ctx.sys.get_timestamp();
+        let initial_start_time = now + TimeDelta::milliseconds(30 * 60 * 1000);
         let delta = -10;
 
         let (user, calendar) = insert_common_data(&ctx).await;
@@ -385,7 +384,7 @@ mod tests {
         let mut ctx = setup_context().await;
         ctx.sys = Arc::new(StaticTimeSys1 {});
 
-        let now = DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis()).unwrap();
+        let now = ctx.sys.get_timestamp();
         let delta = 120;
         let remind_at = now + TimeDelta::milliseconds(120 * 60 * 1000);
 
@@ -450,7 +449,7 @@ mod tests {
         let mut ctx = setup_context().await;
         ctx.sys = Arc::new(StaticTimeSys1 {});
 
-        let now = DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis()).unwrap();
+        let now = ctx.sys.get_timestamp();
 
         let (user, calendar) = insert_common_data(&ctx).await;
         let delta = 120;

--- a/scheduler/crates/api/src/event/get_upcoming_reminders.rs
+++ b/scheduler/crates/api/src/event/get_upcoming_reminders.rs
@@ -27,6 +27,8 @@ async fn get_accounts_from_reminders(
         .iter()
         .map(|r| r.account_id.to_owned())
         .collect::<Vec<_>>();
+    // TODO: to fix
+    #[allow(clippy::unwrap_used)]
     ctx.repos
         .accounts
         .find_many(&account_ids)
@@ -99,12 +101,16 @@ impl UseCase for GetUpcomingRemindersUseCase {
     /// This will run every minute
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
         // Find all occurrences for the next interval and delete them
+        // TODO: to fix
+        #[allow(clippy::unwrap_used)]
         let ts = DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis()).unwrap()
             + TimeDelta::milliseconds(self.reminders_interval);
 
         // Get all reminders and filter out invalid / expired reminders
         let reminders = ctx.repos.reminders.delete_all_before(ts).await;
 
+        // TODO: to fix
+        #[allow(clippy::unwrap_used)]
         let event_lookup = ctx
             .repos
             .events
@@ -148,7 +154,7 @@ mod tests {
     };
 
     async fn setup_context() -> NettuContext {
-        let ctx = _setup_ctx().await;
+        let ctx = _setup_ctx().await.unwrap();
         ctx.repos
             .reminders
             .delete_all_before(DateTime::<Utc>::MAX_UTC)

--- a/scheduler/crates/api/src/event/subscribers/mod.rs
+++ b/scheduler/crates/api/src/event/subscribers/mod.rs
@@ -71,10 +71,15 @@ impl Subscriber<CreateEventUseCase> for CreateSyncedEventsOnEventCreated {
         if synced_google_calendars.is_empty() && synced_outlook_calendars.is_empty() {
             return;
         }
-        let user = match ctx.repos.users.find(&e.user_id).await {
-            Some(u) => u,
-            None => {
+        let user = ctx.repos.users.find(&e.user_id).await;
+        let user = match user {
+            Ok(Some(u)) => u,
+            Ok(None) => {
                 error!("Unable to find user when creating sync events");
+                return;
+            }
+            Err(e) => {
+                error!("Unable to find user when creating sync events {:?}", e);
                 return;
             }
         };
@@ -179,9 +184,13 @@ impl Subscriber<UpdateEventUseCase> for UpdateSyncedEventsOnEventUpdated {
             return;
         }
         let user = match ctx.repos.users.find(&e.user_id).await {
-            Some(u) => u,
-            None => {
+            Ok(Some(u)) => u,
+            Ok(None) => {
                 error!("Unable to find user when updating sync events");
+                return;
+            }
+            Err(e) => {
+                error!("Unable to find user when updating sync events {:?}", e);
                 return;
             }
         };

--- a/scheduler/crates/api/src/event/sync_event_reminders.rs
+++ b/scheduler/crates/api/src/event/sync_event_reminders.rs
@@ -39,6 +39,8 @@ async fn create_event_reminders(
     version: i64,
     ctx: &NettuContext,
 ) -> Result<(), UseCaseError> {
+    // TODO: to fix
+    #[allow(clippy::unwrap_used)]
     let timestamp_now_millis =
         DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis()).unwrap();
     let threshold_millis = timestamp_now_millis + TimeDelta::milliseconds(61 * 1000); // Now + 61 seconds
@@ -201,6 +203,8 @@ impl<'a> UseCase for SyncEventRemindersUseCase<'a> {
                     .repos
                     .event_reminders_generation_jobs
                     .delete_all_before(
+                        // TODO: to fix
+                        #[allow(clippy::unwrap_used)]
                         DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis()).unwrap(),
                     )
                     .await;

--- a/scheduler/crates/api/src/event/sync_event_reminders.rs
+++ b/scheduler/crates/api/src/event/sync_event_reminders.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, TimeDelta, Utc};
+use chrono::{TimeDelta, Utc};
 use futures::future;
 use nettu_scheduler_domain::{Calendar, CalendarEvent, EventRemindersExpansionJob, Reminder};
 use nettu_scheduler_infra::NettuContext;
@@ -39,10 +39,7 @@ async fn create_event_reminders(
     version: i64,
     ctx: &NettuContext,
 ) -> Result<(), UseCaseError> {
-    // TODO: to fix
-    #[allow(clippy::unwrap_used)]
-    let timestamp_now_millis =
-        DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis()).unwrap();
+    let timestamp_now_millis = ctx.sys.get_timestamp();
     let threshold_millis = timestamp_now_millis + TimeDelta::milliseconds(61 * 1000); // Now + 61 seconds
 
     let rrule_set = event.get_rrule_set(&calendar.settings);
@@ -202,11 +199,7 @@ impl<'a> UseCase for SyncEventRemindersUseCase<'a> {
                 let jobs = ctx
                     .repos
                     .event_reminders_generation_jobs
-                    .delete_all_before(
-                        // TODO: to fix
-                        #[allow(clippy::unwrap_used)]
-                        DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis()).unwrap(),
-                    )
+                    .delete_all_before(ctx.sys.get_timestamp())
                     .await;
 
                 let event_ids = jobs

--- a/scheduler/crates/api/src/event/update_event.rs
+++ b/scheduler/crates/api/src/event/update_event.rs
@@ -208,7 +208,7 @@ impl UseCase for UpdateEventUseCase {
             // ? should exdates be deleted when rrules are updated
             e.set_recurrence(rrule_opts, &calendar.settings, true)
         } else if start_or_duration_change && e.recurrence.is_some() {
-            // TODO: to fix
+            // This unwrap is safe as we have checked that recurrence "is_some"
             #[allow(clippy::unwrap_used)]
             e.set_recurrence(e.recurrence.clone().unwrap(), &calendar.settings, true)
         } else {

--- a/scheduler/crates/api/src/event/update_event.rs
+++ b/scheduler/crates/api/src/event/update_event.rs
@@ -148,12 +148,16 @@ impl UseCase for UpdateEventUseCase {
         } = self;
 
         let mut e = match ctx.repos.events.find(event_id).await {
-            Some(event) if event.user_id == user.id => event,
-            _ => {
+            Ok(Some(event)) if event.user_id == user.id => event,
+            Ok(_) => {
                 return Err(UseCaseError::NotFound(
                     "Calendar Event".into(),
                     event_id.clone(),
                 ))
+            }
+            Err(e) => {
+                tracing::error!("Failed to get one event {:?}", e);
+                return Err(UseCaseError::StorageError);
             }
         };
 
@@ -176,12 +180,16 @@ impl UseCase for UpdateEventUseCase {
         }
 
         let calendar = match ctx.repos.calendars.find(&e.calendar_id).await {
-            Some(cal) => cal,
-            _ => {
+            Ok(Some(cal)) => cal,
+            Ok(None) => {
                 return Err(UseCaseError::NotFound(
                     "Calendar".into(),
                     e.calendar_id.clone(),
                 ))
+            }
+            Err(e) => {
+                tracing::error!("Failed to get one calendar {:?}", e);
+                return Err(UseCaseError::StorageError);
             }
         };
 

--- a/scheduler/crates/api/src/event/update_event.rs
+++ b/scheduler/crates/api/src/event/update_event.rs
@@ -208,6 +208,8 @@ impl UseCase for UpdateEventUseCase {
             // ? should exdates be deleted when rrules are updated
             e.set_recurrence(rrule_opts, &calendar.settings, true)
         } else if start_or_duration_change && e.recurrence.is_some() {
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             e.set_recurrence(e.recurrence.clone().unwrap(), &calendar.settings, true)
         } else {
             e.recurrence = None;
@@ -257,7 +259,7 @@ mod test {
             busy: Some(false),
             ..Default::default()
         };
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let res = usecase.execute(&ctx).await;
         assert!(res.is_err());
     }

--- a/scheduler/crates/api/src/lib.rs
+++ b/scheduler/crates/api/src/lib.rs
@@ -107,9 +107,9 @@ impl Application {
         Ok((server, port))
     }
 
-    pub async fn start(self) -> Result<(), std::io::Error> {
+    pub async fn start(self) -> anyhow::Result<()> {
         self.init_default_account().await;
-        self.server.await
+        self.server.await.map_err(|e| anyhow::anyhow!(e))
     }
 
     async fn init_default_account(&self) {

--- a/scheduler/crates/api/src/lib.rs
+++ b/scheduler/crates/api/src/lib.rs
@@ -128,7 +128,7 @@ impl Application {
             .repos
             .accounts
             .find_by_apikey(&secret_api_key)
-            .await
+            .await?
             .is_none()
         {
             let mut account = Account::default();

--- a/scheduler/crates/api/src/schedule/create_schedule.rs
+++ b/scheduler/crates/api/src/schedule/create_schedule.rs
@@ -68,13 +68,13 @@ struct CreateScheduleUseCase {
 #[derive(Debug)]
 enum UseCaseError {
     UserNotFound(ID),
-    Storage,
+    StorageError,
 }
 
 impl From<UseCaseError> for NettuError {
     fn from(e: UseCaseError) -> Self {
         match e {
-            UseCaseError::Storage => Self::InternalError,
+            UseCaseError::StorageError => Self::InternalError,
             UseCaseError::UserNotFound(user_id) => {
                 Self::NotFound(format!("The user with id: {}, was not found.", user_id))
             }
@@ -101,6 +101,7 @@ impl UseCase for CreateScheduleUseCase {
             .users
             .find_by_account_id(&self.user_id, &self.account_id)
             .await
+            .map_err(|_| UseCaseError::StorageError)?
             .ok_or_else(|| UseCaseError::UserNotFound(self.user_id.clone()))?;
 
         let mut schedule = Schedule::new(user.id, user.account_id, &self.timezone);
@@ -114,7 +115,7 @@ impl UseCase for CreateScheduleUseCase {
         let res = ctx.repos.schedules.insert(&schedule).await;
         match res {
             Ok(_) => Ok(UseCaseRes { schedule }),
-            Err(_) => Err(UseCaseError::Storage),
+            Err(_) => Err(UseCaseError::StorageError),
         }
     }
 }

--- a/scheduler/crates/api/src/schedule/create_schedule.rs
+++ b/scheduler/crates/api/src/schedule/create_schedule.rs
@@ -100,11 +100,8 @@ impl UseCase for CreateScheduleUseCase {
             .repos
             .users
             .find_by_account_id(&self.user_id, &self.account_id)
-            .await;
-        if user.is_none() {
-            return Err(UseCaseError::UserNotFound(self.user_id.clone()));
-        }
-        let user = user.unwrap();
+            .await
+            .ok_or_else(|| UseCaseError::UserNotFound(self.user_id.clone()))?;
 
         let mut schedule = Schedule::new(user.id, user.account_id, &self.timezone);
         if let Some(rules) = &self.rules {

--- a/scheduler/crates/api/src/schedule/delete_schedule.rs
+++ b/scheduler/crates/api/src/schedule/delete_schedule.rs
@@ -81,7 +81,12 @@ impl UseCase for DeleteScheduleUseCase {
     const NAME: &'static str = "DeleteSchedule";
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
-        let schedule = ctx.repos.schedules.find(&self.schedule_id).await;
+        let schedule = ctx
+            .repos
+            .schedules
+            .find(&self.schedule_id)
+            .await
+            .map_err(|_| UseCaseError::StorageError)?;
         match schedule {
             Some(schedule) if schedule.user_id == self.user_id => {
                 ctx.repos

--- a/scheduler/crates/api/src/schedule/get_schedules_by_meta.rs
+++ b/scheduler/crates/api/src/schedule/get_schedules_by_meta.rs
@@ -18,6 +18,11 @@ pub async fn get_schedules_by_meta_controller(
         limit: query_params.0.limit.unwrap_or(20),
         skip: query_params.0.skip.unwrap_or(0),
     };
-    let schedules = ctx.repos.schedules.find_by_metadata(query).await;
+    let schedules = ctx
+        .repos
+        .schedules
+        .find_by_metadata(query)
+        .await
+        .map_err(|_| NettuError::InternalError)?;
     Ok(HttpResponse::Ok().json(APIResponse::new(schedules)))
 }

--- a/scheduler/crates/api/src/schedule/update_schedule.rs
+++ b/scheduler/crates/api/src/schedule/update_schedule.rs
@@ -101,8 +101,11 @@ impl UseCase for UpdateScheduleUseCase {
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
         let mut schedule = match ctx.repos.schedules.find(&self.schedule_id).await {
-            Some(cal) if cal.user_id == self.user_id => cal,
-            _ => return Err(UseCaseError::ScheduleNotFound(self.schedule_id.clone())),
+            Ok(Some(cal)) if cal.user_id == self.user_id => cal,
+            Ok(_) => return Err(UseCaseError::ScheduleNotFound(self.schedule_id.clone())),
+            Err(_) => {
+                return Err(UseCaseError::StorageError);
+            }
         };
 
         if let Some(tz) = self.timezone {

--- a/scheduler/crates/api/src/service/create_service_event_intend.rs
+++ b/scheduler/crates/api/src/service/create_service_event_intend.rs
@@ -187,7 +187,8 @@ impl UseCase for CreateServiceEventIntendUseCase {
                                             &service.id,
                                             &user_ids_at_slot,
                                         )
-                                        .await;
+                                        .await
+                                        .map_err(|_| UseCaseError::StorageError)?;
 
                                     let query = RoundRobinAvailabilityAssignment {
                                         members: events
@@ -219,7 +220,8 @@ impl UseCase for CreateServiceEventIntendUseCase {
                                             now,
                                             timestamp_in_two_months,
                                         )
-                                        .await;
+                                        .await
+                                        .map_err(|_| UseCaseError::StorageError)?;
 
                                     let query = RoundRobinEqualDistributionAssignment {
                                         events: service_events,
@@ -283,7 +285,12 @@ impl UseCase for CreateServiceEventIntendUseCase {
             }
         };
 
-        let selected_hosts = ctx.repos.users.find_many(&selected_host_user_ids).await;
+        let selected_hosts = ctx
+            .repos
+            .users
+            .find_many(&selected_host_user_ids)
+            .await
+            .map_err(|_| UseCaseError::StorageError)?;
 
         Ok(UseCaseRes {
             selected_hosts,

--- a/scheduler/crates/api/src/service/create_service_event_intend.rs
+++ b/scheduler/crates/api/src/service/create_service_event_intend.rs
@@ -14,6 +14,7 @@ use nettu_scheduler_domain::{
     ID,
 };
 use nettu_scheduler_infra::NettuContext;
+use tracing::warn;
 
 use super::get_service_bookingslots;
 use crate::{
@@ -194,9 +195,10 @@ impl UseCase for CreateServiceEventIntendUseCase {
                                             .map(|e| (e.user_id, e.created))
                                             .collect(),
                                     };
-                                    // TODO: to fix
-                                    #[allow(clippy::expect_used)]
-                                    let selected_user_id = query.assign().expect("At least one host can be picked when there are at least one host available");
+                                    let selected_user_id = query.assign().ok_or_else(|| {
+                                        warn!("At least one host can be picked when there are at least one host available");
+                                        UseCaseError::UserNotAvailable
+                                    })?;
                                     vec![selected_user_id]
                                 }
                             }
@@ -223,9 +225,10 @@ impl UseCase for CreateServiceEventIntendUseCase {
                                         events: service_events,
                                         user_ids: user_ids_at_slot,
                                     };
-                                    // TODO: to fix
-                                    #[allow(clippy::expect_used)]
-                                    let selected_user_id = query.assign().expect("At least one host can be picked when there are at least one host available");
+                                    let selected_user_id = query.assign().ok_or_else(|| {
+                                        warn!("At least one host can be picked when there are at least one host available");
+                                        UseCaseError::UserNotAvailable
+                                    })?;
                                     vec![selected_user_id]
                                 }
                             }

--- a/scheduler/crates/api/src/service/create_service_event_intend.rs
+++ b/scheduler/crates/api/src/service/create_service_event_intend.rs
@@ -194,6 +194,8 @@ impl UseCase for CreateServiceEventIntendUseCase {
                                             .map(|e| (e.user_id, e.created))
                                             .collect(),
                                     };
+                                    // TODO: to fix
+                                    #[allow(clippy::expect_used)]
                                     let selected_user_id = query.assign().expect("At least one host can be picked when there are at least one host available");
                                     vec![selected_user_id]
                                 }
@@ -221,6 +223,8 @@ impl UseCase for CreateServiceEventIntendUseCase {
                                         events: service_events,
                                         user_ids: user_ids_at_slot,
                                     };
+                                    // TODO: to fix
+                                    #[allow(clippy::expect_used)]
                                     let selected_user_id = query.assign().expect("At least one host can be picked when there are at least one host available");
                                     vec![selected_user_id]
                                 }

--- a/scheduler/crates/api/src/service/delete_service.rs
+++ b/scheduler/crates/api/src/service/delete_service.rs
@@ -66,7 +66,12 @@ impl UseCase for DeleteServiceUseCase {
     const NAME: &'static str = "DeleteService";
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
-        let res = ctx.repos.services.find(&self.service_id).await;
+        let res = ctx
+            .repos
+            .services
+            .find(&self.service_id)
+            .await
+            .map_err(|_| UseCaseError::StorageError)?;
         match res {
             Some(service) if service.account_id == self.account.id => {
                 ctx.repos

--- a/scheduler/crates/api/src/service/get_service_bookingslots.rs
+++ b/scheduler/crates/api/src/service/get_service_bookingslots.rs
@@ -361,7 +361,8 @@ impl GetServiceBookingSlotsUseCase {
         }
 
         if !google_busy_calendar_ids.is_empty() {
-            // TODO: no unwrap
+            // TODO: to fix
+            #[allow(clippy::expect_used)]
             let user = ctx
                 .repos
                 .users
@@ -390,7 +391,8 @@ impl GetServiceBookingSlotsUseCase {
         }
 
         if !outlook_busy_calendar_ids.is_empty() {
-            // TODO: no unwrap
+            // TODO: to fix
+            #[allow(clippy::expect_used)]
             let user = ctx
                 .repos
                 .users
@@ -421,6 +423,8 @@ impl GetServiceBookingSlotsUseCase {
         mut timespan: TimeSpan,
         ctx: &NettuContext,
     ) -> Result<TimeSpan, ()> {
+        // TODO: to fix
+        #[allow(clippy::unwrap_used)]
         let first_available = DateTime::from_timestamp_millis(ctx.sys.get_timestamp_millis())
             .unwrap()
             + TimeDelta::milliseconds(user.closest_booking_time * 60 * 1000);
@@ -428,6 +432,8 @@ impl GetServiceBookingSlotsUseCase {
             timespan = TimeSpan::new(first_available, timespan.end());
         }
         if let Some(furthest_booking_time) = user.furthest_booking_time {
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             let last_available = DateTime::from_timestamp_micros(ctx.sys.get_timestamp_millis())
                 .unwrap()
                 + TimeDelta::milliseconds(furthest_booking_time * 60 * 1000);
@@ -532,7 +538,7 @@ mod test {
     }
 
     async fn setup() -> TestContext {
-        let mut ctx = setup_context().await;
+        let mut ctx = setup_context().await.unwrap();
         ctx.sys = Arc::new(DummySys {});
 
         let account = Account::default();

--- a/scheduler/crates/api/src/service/get_services_by_meta.rs
+++ b/scheduler/crates/api/src/service/get_services_by_meta.rs
@@ -18,6 +18,11 @@ pub async fn get_services_by_meta_controller(
         limit: query_params.0.limit.unwrap_or(20),
         skip: query_params.0.skip.unwrap_or(0),
     };
-    let services = ctx.repos.services.find_by_metadata(query).await;
+    let services = ctx
+        .repos
+        .services
+        .find_by_metadata(query)
+        .await
+        .map_err(|_| NettuError::InternalError)?;
     Ok(HttpResponse::Ok().json(APIResponse::new(services)))
 }

--- a/scheduler/crates/api/src/service/remove_busy_calendar.rs
+++ b/scheduler/crates/api/src/service/remove_busy_calendar.rs
@@ -75,6 +75,7 @@ impl UseCase for RemoveBusyCalendarUseCase {
             .users
             .find_by_account_id(&self.user_id, &self.account.id)
             .await
+            .map_err(|_| UseCaseError::StorageError)?
             .ok_or(UseCaseError::UserNotFound)?;
 
         // Check if busy calendar exists

--- a/scheduler/crates/api/src/service/remove_service_event_intend.rs
+++ b/scheduler/crates/api/src/service/remove_service_event_intend.rs
@@ -70,8 +70,9 @@ impl UseCase for RemoveServiceEventIntendUseCase {
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
         match ctx.repos.services.find(&self.service_id).await {
-            Some(s) if s.account_id == self.account.id => (),
-            _ => return Err(UseCaseError::ServiceNotFound),
+            Ok(Some(s)) if s.account_id == self.account.id => (),
+            Ok(_) => return Err(UseCaseError::ServiceNotFound),
+            Err(_) => return Err(UseCaseError::StorageError),
         };
         ctx.repos
             .reservations

--- a/scheduler/crates/api/src/service/update_service.rs
+++ b/scheduler/crates/api/src/service/update_service.rs
@@ -72,8 +72,9 @@ impl UseCase for UpdateServiceUseCase {
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
         let mut service = match ctx.repos.services.find(&self.service_id).await {
-            Some(service) if service.account_id == self.account_id => service,
-            _ => return Err(UseCaseError::ServiceNotFound(self.service_id.clone())),
+            Ok(Some(service)) if service.account_id == self.account_id => service,
+            Ok(_) => return Err(UseCaseError::ServiceNotFound(self.service_id.clone())),
+            Err(_) => return Err(UseCaseError::StorageError),
         };
 
         if let Some(metadata) = &self.metadata {

--- a/scheduler/crates/api/src/service/update_service_user.rs
+++ b/scheduler/crates/api/src/service/update_service_user.rs
@@ -89,8 +89,9 @@ impl UseCase for UpdateServiceUserUseCase {
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
         let _service = match ctx.repos.services.find(&self.service_id).await {
-            Some(service) if service.account_id == self.account.id => service,
-            _ => return Err(UseCaseError::ServiceNotFound),
+            Ok(Some(service)) if service.account_id == self.account.id => service,
+            Ok(_) => return Err(UseCaseError::ServiceNotFound),
+            Err(_) => return Err(UseCaseError::StorageError),
         };
 
         let mut user_resource = match ctx
@@ -99,8 +100,9 @@ impl UseCase for UpdateServiceUserUseCase {
             .find(&self.service_id, &self.user_id)
             .await
         {
-            Some(res) => res,
-            _ => return Err(UseCaseError::UserNotFound),
+            Ok(Some(res)) => res,
+            Ok(None) => return Err(UseCaseError::UserNotFound),
+            Err(_) => return Err(UseCaseError::StorageError),
         };
 
         update_resource_values(

--- a/scheduler/crates/api/src/shared/auth/route_guards.rs
+++ b/scheduler/crates/api/src/shared/auth/route_guards.rs
@@ -37,13 +37,13 @@ pub async fn auth_user_req(
     req: &HttpRequest,
     account: &Account,
     ctx: &NettuContext,
-) -> Option<(User, Policy)> {
+) -> anyhow::Result<Option<(User, Policy)>> {
     let token = req.headers().get("authorization");
-    match token {
+    let token = match token {
         Some(token) => {
             let token = match token.to_str() {
                 Ok(token) => parse_authtoken_header(token),
-                Err(_) => return None,
+                Err(_) => return Ok(None),
             };
             match decode_token(account, &token) {
                 // In addition to checking that the request comes with a valid jwt we also
@@ -54,6 +54,7 @@ pub async fn auth_user_req(
                     .users
                     .find_by_account_id(&claims.nettu_scheduler_user_id, &account.id)
                     .await
+                    .map_err(|_| NettuError::InternalError)?
                     .map(|user| (user, claims.scheduler_policy.unwrap_or_default())),
                 Err(e) => {
                     warn!("Decode token error: {:?}", e);
@@ -62,14 +63,18 @@ pub async fn auth_user_req(
             }
         }
         None => None,
-    }
+    };
+    Ok(token)
 }
 
 /// Finds out which `Account` the client is associated with.
-pub async fn get_client_account(req: &HttpRequest, ctx: &NettuContext) -> Option<Account> {
+pub async fn get_client_account(
+    req: &HttpRequest,
+    ctx: &NettuContext,
+) -> anyhow::Result<Option<Account>> {
     match get_nettu_account_header(req) {
         Some(Ok(account_id)) => ctx.repos.accounts.find(&account_id).await,
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -110,15 +115,17 @@ pub async fn protect_route(
     req: &HttpRequest,
     ctx: &NettuContext,
 ) -> Result<(User, Policy), NettuError> {
-    let account = match get_client_account(req, ctx).await {
-        Some(account) => account,
-        None => {
-            return Err(NettuError::Unauthorized(
-                "Unable to find the account the client belongs to".into(),
-            ))
-        }
-    };
-    let res = auth_user_req(req, &account, ctx).await;
+    let account = get_client_account(req, ctx)
+        .await
+        .map_err(|_| NettuError::InternalError)?
+        .ok_or_else(|| {
+            NettuError::UnidentifiableClient(
+                "Could not find out which account the client belongs to".into(),
+            )
+        })?;
+    let res = auth_user_req(req, &account, ctx)
+        .await
+        .map_err(|_| NettuError::InternalError)?;
 
     match res {
         Some(user_and_policy) => Ok(user_and_policy),
@@ -149,14 +156,14 @@ pub async fn protect_account_route(
         }
     };
 
-    let account = ctx.repos.accounts.find_by_apikey(api_key).await;
-
-    match account {
-        Some(acc) => Ok(acc),
-        None => Err(NettuError::Unauthorized(
-            "Invalid api-key provided in x-api-key header".to_string(),
-        )),
-    }
+    ctx.repos
+        .accounts
+        .find_by_apikey(api_key)
+        .await
+        .map_err(|_| NettuError::InternalError)?
+        .ok_or_else(|| {
+            NettuError::Unauthorized("Invalid api-key provided in x-api-key header".to_string())
+        })
 }
 
 /// Only checks which account the request is connected to.
@@ -170,12 +177,16 @@ pub async fn protect_public_account_route(
         Some(res) => {
             let account_id = res?;
 
-            match ctx.repos.accounts.find(&account_id).await {
-                Some(acc) => Ok(acc),
-                None => Err(NettuError::UnidentifiableClient(
-                    "Could not find out which account the client belongs to".into(),
-                )),
-            }
+            ctx.repos
+                .accounts
+                .find(&account_id)
+                .await
+                .map_err(|_| NettuError::InternalError)?
+                .ok_or_else(|| {
+                    NettuError::UnidentifiableClient(
+                        "Could not find out which account the client belongs to".into(),
+                    )
+                })
         }
         // No nettu-account header, then check if this is an admin client
         None => protect_account_route(http_req, ctx).await,
@@ -190,11 +201,12 @@ pub async fn account_can_modify_user(
     ctx: &NettuContext,
 ) -> Result<User, NettuError> {
     match ctx.repos.users.find(user_id).await {
-        Some(user) if user.account_id == account.id => Ok(user),
-        _ => Err(NettuError::NotFound(format!(
+        Ok(Some(user)) if user.account_id == account.id => Ok(user),
+        Ok(_) => Err(NettuError::NotFound(format!(
             "User with id: {} was not found",
             user_id
         ))),
+        Err(_) => Err(NettuError::InternalError),
     }
 }
 
@@ -206,11 +218,12 @@ pub async fn account_can_modify_calendar(
     ctx: &NettuContext,
 ) -> Result<Calendar, NettuError> {
     match ctx.repos.calendars.find(calendar_id).await {
-        Some(cal) if cal.account_id == account.id => Ok(cal),
-        _ => Err(NettuError::NotFound(format!(
+        Ok(Some(cal)) if cal.account_id == account.id => Ok(cal),
+        Ok(_) => Err(NettuError::NotFound(format!(
             "Calendar with id: {} was not found",
             calendar_id
         ))),
+        Err(_) => Err(NettuError::InternalError),
     }
 }
 
@@ -222,11 +235,12 @@ pub async fn account_can_modify_event(
     ctx: &NettuContext,
 ) -> Result<CalendarEvent, NettuError> {
     match ctx.repos.events.find(event_id).await {
-        Some(event) if event.account_id == account.id => Ok(event),
-        _ => Err(NettuError::NotFound(format!(
+        Ok(Some(event)) if event.account_id == account.id => Ok(event),
+        Ok(_) => Err(NettuError::NotFound(format!(
             "Calendar event with id: {} was not found",
             event_id
         ))),
+        Err(_) => Err(NettuError::InternalError),
     }
 }
 
@@ -238,11 +252,12 @@ pub async fn account_can_modify_schedule(
     ctx: &NettuContext,
 ) -> Result<Schedule, NettuError> {
     match ctx.repos.schedules.find(schedule_id).await {
-        Some(schedule) if schedule.account_id == account.id => Ok(schedule),
-        _ => Err(NettuError::NotFound(format!(
+        Ok(Some(schedule)) if schedule.account_id == account.id => Ok(schedule),
+        Ok(_) => Err(NettuError::NotFound(format!(
             "Schedule with id: {} was not found",
             schedule_id
         ))),
+        Err(_) => Err(NettuError::InternalError),
     }
 }
 

--- a/scheduler/crates/api/src/shared/auth/route_guards.rs
+++ b/scheduler/crates/api/src/shared/auth/route_guards.rs
@@ -291,7 +291,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn decodes_valid_token_for_existing_user_in_account() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = setup_account(&ctx).await;
         let user = User::new(account.id.clone(), None);
         ctx.repos.users.insert(&user).await.unwrap();
@@ -308,7 +308,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn decodes_valid_token_and_rejects_if_user_is_in_different_account() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = setup_account(&ctx).await;
         let account2 = setup_account(&ctx).await;
         let user = User::new(account2.id.clone(), None); // user belongs to account2
@@ -327,7 +327,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn rejects_expired_token() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = setup_account(&ctx).await;
         let user = User::new(account.id.clone(), None);
         ctx.repos.users.insert(&user).await.unwrap();
@@ -344,7 +344,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn rejects_valid_token_without_account_header() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = setup_account(&ctx).await;
         let user = User::new(account.id.clone(), None);
         ctx.repos.users.insert(&user).await.unwrap();
@@ -360,7 +360,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn rejects_valid_token_with_invalid_account_header() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = setup_account(&ctx).await;
         let user = User::new(account.id.clone(), None);
         ctx.repos.users.insert(&user).await.unwrap();
@@ -377,7 +377,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn rejects_garbage_token_with_valid_account_header() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let _account = setup_account(&ctx).await;
         let token = "sajfosajfposajfopaso12";
 
@@ -391,7 +391,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn rejects_invalid_authz_header() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = setup_account(&ctx).await;
         let user = User::new(account.id.clone(), None);
         ctx.repos.users.insert(&user).await.unwrap();
@@ -407,7 +407,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn rejects_req_without_headers() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let _account = setup_account(&ctx).await;
 
         let req = TestRequest::default().to_http_request();

--- a/scheduler/crates/api/src/user/create_user.rs
+++ b/scheduler/crates/api/src/user/create_user.rs
@@ -69,7 +69,13 @@ impl UseCase for CreateUserUseCase {
         let mut user = User::new(self.account_id.clone(), self.user_id.clone());
         user.metadata = self.metadata.clone();
 
-        if let Some(_existing_user) = ctx.repos.users.find(&user.id).await {
+        let existing_user = ctx
+            .repos
+            .users
+            .find(&user.id)
+            .await
+            .map_err(|_| UseCaseError::StorageError)?;
+        if let Some(_existing_user) = existing_user {
             return Err(UseCaseError::UserAlreadyExists);
         }
 

--- a/scheduler/crates/api/src/user/delete_user.rs
+++ b/scheduler/crates/api/src/user/delete_user.rs
@@ -66,13 +66,15 @@ impl UseCase for DeleteUserUseCase {
 
     async fn execute(&mut self, ctx: &NettuContext) -> Result<Self::Response, Self::Error> {
         let user = match ctx.repos.users.find(&self.user_id).await {
-            Some(u) if u.account_id == self.account.id => {
+            Ok(Some(u)) if u.account_id == self.account.id => {
                 match ctx.repos.users.delete(&self.user_id).await {
-                    Some(u) => u,
-                    None => return Err(UseCaseError::StorageError),
+                    Ok(Some(u)) => u,
+                    Ok(None) => return Err(UseCaseError::StorageError),
+                    Err(_) => return Err(UseCaseError::StorageError),
                 }
             }
-            _ => return Err(UseCaseError::UserNotFound(self.user_id.clone())),
+            Ok(_) => return Err(UseCaseError::UserNotFound(self.user_id.clone())),
+            Err(_) => return Err(UseCaseError::StorageError),
         };
 
         Ok(UseCaseRes { user })

--- a/scheduler/crates/api/src/user/get_multiple_users_freebusy.rs
+++ b/scheduler/crates/api/src/user/get_multiple_users_freebusy.rs
@@ -166,6 +166,8 @@ impl GetMultipleFreeBusyUseCase {
         events
             .into_iter()
             .map(|event| {
+                // TODO: to fix
+                #[allow(clippy::unwrap_used)]
                 let calendar = calendars_lookup
                     .get(&event.calendar_id.to_string())
                     .unwrap();
@@ -187,7 +189,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn multiple_freebusy_works() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);

--- a/scheduler/crates/api/src/user/get_user_freebusy.rs
+++ b/scheduler/crates/api/src/user/get_user_freebusy.rs
@@ -67,12 +67,14 @@ pub struct GetFreeBusyResponse {
 
 #[derive(Debug)]
 pub enum UseCaseError {
+    InternalError,
     InvalidTimespan,
 }
 
 impl From<UseCaseError> for NettuError {
     fn from(e: UseCaseError) -> Self {
         match e {
+            UseCaseError::InternalError => Self::InternalError,
             UseCaseError::InvalidTimespan => {
                 Self::BadClientData("The provided start_ts and end_ts is invalid".into())
             }
@@ -97,6 +99,7 @@ impl UseCase for GetFreeBusyUseCase {
         let busy_event_instances = self
             .get_event_instances_from_calendars(&timespan, ctx)
             .await
+            .map_err(|_| UseCaseError::InternalError)?
             .into_iter()
             .filter(|e| e.busy)
             .collect::<Vec<_>>();
@@ -115,14 +118,14 @@ impl GetFreeBusyUseCase {
         &self,
         timespan: &TimeSpan,
         ctx: &NettuContext,
-    ) -> Vec<EventInstance> {
+    ) -> anyhow::Result<Vec<EventInstance>> {
         let calendar_ids = match &self.calendar_ids {
             Some(ids) if !ids.is_empty() => ids,
-            _ => return Vec::new(),
+            _ => return Ok(Vec::new()),
         };
 
         // can probably make query to event repo instead
-        let mut calendars = ctx.repos.calendars.find_by_user(&self.user_id).await;
+        let mut calendars = ctx.repos.calendars.find_by_user(&self.user_id).await?;
 
         if !calendar_ids.is_empty() {
             calendars.retain(|cal| calendar_ids.contains(&cal.id));
@@ -139,26 +142,31 @@ impl GetFreeBusyUseCase {
                 .find_by_calendar(&calendar.id, Some(timespan))
         });
 
-        join_all(all_events_futures)
-            .await
-            .into_iter()
-            .map(|events_res| events_res.unwrap_or_default())
-            .flat_map(|events| {
-                events
-                    .into_iter()
-                    .map(|event| {
-                        // TODO: to fix
-                        #[allow(clippy::unwrap_used)]
+        let events: Vec<Result<Vec<nettu_scheduler_domain::CalendarEvent>, anyhow::Error>> =
+            join_all(all_events_futures).await.into_iter().collect();
+
+        let mut all_expanded_events = Vec::new();
+        for events in events {
+            match events {
+                Ok(events) => {
+                    for event in events {
                         let calendar = calendars_lookup
                             .get(&event.calendar_id.to_string())
-                            .unwrap();
-                        event.expand(Some(timespan), &calendar.settings)
-                    })
-                    // It is possible that there are no instances in the expanded event, should remove them
-                    .filter(|instances| !instances.is_empty())
-            })
-            .flatten()
-            .collect::<Vec<_>>()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("Calendar with id: {} not found", event.calendar_id)
+                            })?;
+                        let expanded_events = event.expand(Some(timespan), &calendar.settings);
+
+                        all_expanded_events.extend(expanded_events);
+                    }
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(all_expanded_events)
     }
 }
 

--- a/scheduler/crates/api/src/user/get_user_freebusy.rs
+++ b/scheduler/crates/api/src/user/get_user_freebusy.rs
@@ -147,6 +147,8 @@ impl GetFreeBusyUseCase {
                 events
                     .into_iter()
                     .map(|event| {
+                        // TODO: to fix
+                        #[allow(clippy::unwrap_used)]
                         let calendar = calendars_lookup
                             .get(&event.calendar_id.to_string())
                             .unwrap();
@@ -188,7 +190,7 @@ mod test {
     #[actix_web::main]
     #[test]
     async fn freebusy_works() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);

--- a/scheduler/crates/api/src/user/get_users_by_meta.rs
+++ b/scheduler/crates/api/src/user/get_users_by_meta.rs
@@ -18,6 +18,11 @@ pub async fn get_users_by_meta_controller(
         limit: query_params.0.limit.unwrap_or(20),
         skip: query_params.0.skip.unwrap_or(0),
     };
-    let users = ctx.repos.users.find_by_metadata(query).await;
+    let users = ctx
+        .repos
+        .users
+        .find_by_metadata(query)
+        .await
+        .map_err(|_| NettuError::InternalError)?;
     Ok(HttpResponse::Ok().json(APIResponse::new(users)))
 }

--- a/scheduler/crates/api/src/user/update_user.rs
+++ b/scheduler/crates/api/src/user/update_user.rs
@@ -74,8 +74,9 @@ impl UseCase for UpdateUserUseCase {
             .find_by_account_id(&self.user_id, &self.account_id)
             .await
         {
-            Some(user) => user,
-            None => return Err(UseCaseError::UserNotFound(self.user_id.clone())),
+            Ok(Some(user)) => user,
+            Ok(None) => return Err(UseCaseError::UserNotFound(self.user_id.clone())),
+            Err(_) => return Err(UseCaseError::StorageError),
         };
 
         if let Some(metadata) = &self.metadata {

--- a/scheduler/crates/domain/Cargo.toml
+++ b/scheduler/crates/domain/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 rrule = "0.12.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 chrono-tz = { version = "0.8.1", features = ["serde"] }
-anyhow = "1.0.0"
+anyhow = "1.0"
 url = "2.2.0"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 jsonwebtoken = "7"

--- a/scheduler/crates/domain/src/booking_slots.rs
+++ b/scheduler/crates/domain/src/booking_slots.rs
@@ -82,6 +82,7 @@ impl ServiceBookingSlotsDate {
                 break;
             } else {
                 // Delete slot
+                #[allow(clippy::unwrap_used)]
                 date_slots.push(slots.pop_front().unwrap());
             }
         }
@@ -219,6 +220,7 @@ pub fn validate_bookingslots_query(
             0,
         )
         .unwrap();
+    #[allow(clippy::unwrap_used)]
     let start_time = start_date
         .with_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap())
         .unwrap()
@@ -233,6 +235,7 @@ pub fn validate_bookingslots_query(
             0,
         )
         .unwrap();
+    #[allow(clippy::unwrap_used)]
     let end_time = end_date
         .with_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap())
         .unwrap()

--- a/scheduler/crates/domain/src/date.rs
+++ b/scheduler/crates/domain/src/date.rs
@@ -14,8 +14,11 @@ pub fn is_valid_date(datestr: &str) -> anyhow::Result<(i32, u32, u32)> {
         return Err(anyhow::Error::msg(datestr));
     }
 
+    #[allow(clippy::unwrap_used)]
     let year = year.unwrap();
+    #[allow(clippy::unwrap_used)]
     let month = month.unwrap();
+    #[allow(clippy::unwrap_used)]
     let day = day.unwrap();
     if !(1970..=2100).contains(&year) || !(1..=12).contains(&month) {
         return Err(anyhow::Error::msg(datestr));

--- a/scheduler/crates/domain/src/event.rs
+++ b/scheduler/crates/domain/src/event.rs
@@ -81,6 +81,8 @@ impl CalendarEvent {
             Some(recurrence) => {
                 let rrule_options =
                     recurrence.get_parsed_options(self.start_time, calendar_settings);
+                // TODO: to fix
+                #[allow(clippy::unwrap_used)]
                 let options = rrule_options.get_rrule().first().unwrap();
                 if (options.get_count().unwrap_or(0) > 0) || options.get_until().is_some() {
                     let expand = self.expand(None, calendar_settings);
@@ -123,6 +125,8 @@ impl CalendarEvent {
             for exdate in &self.exdates {
                 rrule_set = rrule_set.exdate(exdate.with_timezone(&tzid));
             }
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             let rrule = rrule_options.get_rrule().first().unwrap();
             rrule_set = rrule_set.rrule(rrule.clone());
             rrule_set
@@ -139,6 +143,8 @@ impl CalendarEvent {
                 let rrule_options =
                     recurrence.get_parsed_options(self.start_time, calendar_settings);
                 let tzid = rrule_options.get_dt_start().timezone();
+                // TODO: to fix
+                #[allow(clippy::unwrap_used)]
                 let rrule_set = self.get_rrule_set(calendar_settings).unwrap();
 
                 let instances = match timespan {

--- a/scheduler/crates/domain/src/event.rs
+++ b/scheduler/crates/domain/src/event.rs
@@ -81,15 +81,17 @@ impl CalendarEvent {
             Some(recurrence) => {
                 let rrule_options =
                     recurrence.get_parsed_options(self.start_time, calendar_settings);
-                // TODO: to fix
-                #[allow(clippy::unwrap_used)]
-                let options = rrule_options.get_rrule().first().unwrap();
-                if (options.get_count().unwrap_or(0) > 0) || options.get_until().is_some() {
-                    let expand = self.expand(None, calendar_settings);
-                    self.end_time = expand
-                        .last()
-                        .map(|l| l.end_time)
-                        .unwrap_or(DateTime::<Utc>::MIN_UTC);
+                let options = rrule_options.get_rrule().first();
+                if let Some(options) = options {
+                    if (options.get_count().unwrap_or(0) > 0) || options.get_until().is_some() {
+                        let expand = self.expand(None, calendar_settings);
+                        self.end_time = expand
+                            .last()
+                            .map(|l| l.end_time)
+                            .unwrap_or(DateTime::<Utc>::MIN_UTC);
+                    } else {
+                        self.end_time = DateTime::<Utc>::MAX_UTC;
+                    }
                 } else {
                     self.end_time = DateTime::<Utc>::MAX_UTC;
                 }
@@ -118,19 +120,19 @@ impl CalendarEvent {
     }
 
     pub fn get_rrule_set(&self, calendar_settings: &CalendarSettings) -> Option<RRuleSet> {
-        self.recurrence.clone().map(|recurrence| {
+        if let Some(recurrence) = self.recurrence.clone() {
             let rrule_options = recurrence.get_parsed_options(self.start_time, calendar_settings);
             let tzid = rrule_options.get_dt_start().timezone();
             let mut rrule_set = RRuleSet::new(*rrule_options.get_dt_start());
             for exdate in &self.exdates {
                 rrule_set = rrule_set.exdate(exdate.with_timezone(&tzid));
             }
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            let rrule = rrule_options.get_rrule().first().unwrap();
+            let rrule = rrule_options.get_rrule().first()?;
             rrule_set = rrule_set.rrule(rrule.clone());
-            rrule_set
-        })
+            Some(rrule_set)
+        } else {
+            None
+        }
     }
 
     pub fn expand(

--- a/scheduler/crates/domain/src/event_instance.rs
+++ b/scheduler/crates/domain/src/event_instance.rs
@@ -34,6 +34,7 @@ impl CompatibleInstances {
                 compatible_events.push_back(instance);
                 continue;
             }
+            #[allow(clippy::unwrap_used)]
             if let Some(merged) = EventInstance::merge(&instance, compatible_events.back().unwrap())
             {
                 let len = compatible_events.len();
@@ -95,8 +96,7 @@ impl CompatibleInstances {
     }
 
     pub fn remove_all_after(&mut self, timespan: DateTime<Utc>) {
-        while !self.events.is_empty() {
-            let last = self.events.get_mut(self.events.len() - 1).unwrap();
+        while let Some(last) = self.events.back_mut() {
             if last.end_time <= timespan {
                 break;
             }
@@ -251,7 +251,9 @@ impl EventInstance {
                     conflict = true;
 
                     let mut events = events.inner();
+                    #[allow(clippy::unwrap_used)]
                     let last_event = events.pop_back().unwrap();
+                    #[allow(clippy::unwrap_used)]
                     let first_event = events.pop_front().unwrap();
 
                     let mut events = CompatibleInstances::new(vec![last_event.clone()]);

--- a/scheduler/crates/domain/src/providers/outlook.rs
+++ b/scheduler/crates/domain/src/providers/outlook.rs
@@ -22,6 +22,8 @@ impl OutlookCalendarEventTime {
     pub fn get_timestamp_millis(&self) -> i64 {
         let timezone = self.time_zone.parse::<Tz>().unwrap_or(UTC);
 
+        // TODO: to fix
+        #[allow(clippy::unwrap_used)]
         DateTime::parse_from_str(
             &self.date_time[..self.date_time.find('.').unwrap()],
             "%FT%T",

--- a/scheduler/crates/domain/src/schedule.rs
+++ b/scheduler/crates/domain/src/schedule.rs
@@ -49,6 +49,8 @@ impl Schedule {
     pub fn set_rules(&mut self, rules: &[ScheduleRule]) {
         let now = Utc::now();
         let min_date = now - Duration::days(2);
+
+        #[allow(clippy::unwrap_used)]
         let max_date = (now + Duration::days(365 * 5))
             .with_month(1)
             .unwrap()
@@ -240,6 +242,8 @@ impl ScheduleRule {
             self.intervals.splice(10.., Vec::new());
         }
         // earliest start first
+        // TODO: to fix
+        #[allow(clippy::unwrap_used)]
         self.intervals
             .sort_by(|i1, i2| i1.start.partial_cmp(&i2.start).unwrap());
 
@@ -269,6 +273,8 @@ impl ScheduleRule {
 
         let mut remove_intervals = remove_intervals.keys().copied().collect::<Vec<_>>();
         // largest index first
+        // TODO: to fix
+        #[allow(clippy::unwrap_used)]
         remove_intervals.sort_by(|i1, i2| i2.partial_cmp(i1).unwrap());
         for index in remove_intervals {
             self.intervals.remove(index);

--- a/scheduler/crates/domain/src/shared/recurrence.rs
+++ b/scheduler/crates/domain/src/shared/recurrence.rs
@@ -155,6 +155,8 @@ impl RRuleOptions {
             rule = rule.until(until.with_timezone(&rrule::Tz::Tz(chrono_tz::UTC)));
         }
 
+        // TODO: to fix
+        #[allow(clippy::unwrap_used)]
         rule.build(dtstart.with_timezone(&rrule::Tz::Tz(chrono_tz::UTC)))
             .unwrap()
 
@@ -225,6 +227,8 @@ impl WeekDay {
     }
 
     pub fn new(weekday: Weekday) -> Self {
+        // TODO: to fix
+        #[allow(clippy::unwrap_used)]
         Self::create(weekday, None).unwrap()
     }
 

--- a/scheduler/crates/infra/Cargo.toml
+++ b/scheduler/crates/infra/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1"
 async-trait = "0.1.42"
 chrono = { version = "0.4.19", features = ["serde"] }
 chrono-tz = { version = "0.8.1", features = ["serde"] }
-anyhow = "1.0.0"
+anyhow = "1.0"
 tokio = { version = "1", features = ["macros"] }
 tracing = "0.1.25"
 reqwest = { version = "0.12", features = ["json"] }

--- a/scheduler/crates/infra/src/config.rs
+++ b/scheduler/crates/infra/src/config.rs
@@ -42,6 +42,7 @@ impl Config {
                     "The given PORT: {} is not valid, falling back to the default port: {}.",
                     port, default_port
                 );
+                #[allow(clippy::unwrap_used)]
                 default_port.parse::<usize>().unwrap()
             }
         };

--- a/scheduler/crates/infra/src/lib.rs
+++ b/scheduler/crates/infra/src/lib.rs
@@ -9,7 +9,7 @@ pub use config::Config;
 use repos::Repos;
 pub use repos::{BusyCalendarIdentifier, ExternalBusyCalendarIdentifier, MetadataFindQuery};
 pub use services::*;
-use sqlx::{migrate::MigrateError, postgres::PgPoolOptions};
+use sqlx::postgres::PgPoolOptions;
 pub use system::ISys;
 use system::RealSys;
 
@@ -25,39 +25,35 @@ struct ContextParams {
 }
 
 impl NettuContext {
-    async fn create(params: ContextParams) -> Self {
-        let repos = Repos::create_postgres(&params.postgres_connection_string)
-            .await
-            .expect("Postgres credentials must be set and valid");
-        Self {
+    async fn create(params: ContextParams) -> anyhow::Result<Self> {
+        let repos = Repos::create_postgres(&params.postgres_connection_string).await?;
+        Ok(Self {
             repos,
             config: Config::new(),
             sys: Arc::new(RealSys {}),
-        }
+        })
     }
 }
 
 /// Will setup the infrastructure context given the environment
-pub async fn setup_context() -> NettuContext {
+pub async fn setup_context() -> anyhow::Result<NettuContext> {
     NettuContext::create(ContextParams {
-        postgres_connection_string: get_psql_connection_string(),
+        postgres_connection_string: get_psql_connection_string()?,
     })
     .await
 }
 
-fn get_psql_connection_string() -> String {
+fn get_psql_connection_string() -> anyhow::Result<String> {
     const PSQL_CONNECTION_STRING: &str = "DATABASE_URL";
 
-    std::env::var(PSQL_CONNECTION_STRING)
-        .unwrap_or_else(|_| panic!("{} env var to be present.", PSQL_CONNECTION_STRING))
+    Ok(std::env::var(PSQL_CONNECTION_STRING)?)
 }
 
-pub async fn run_migration() -> Result<(), MigrateError> {
+pub async fn run_migration() -> anyhow::Result<()> {
     let pool = PgPoolOptions::new()
         .max_connections(5)
-        .connect(&get_psql_connection_string())
-        .await
-        .expect("TO CONNECT TO POSTGRES");
+        .connect(&get_psql_connection_string()?)
+        .await?;
 
-    sqlx::migrate!().run(&pool).await
+    sqlx::migrate!().run(&pool).await.map_err(|e| e.into())
 }

--- a/scheduler/crates/infra/src/repos/account/mod.rs
+++ b/scheduler/crates/infra/src/repos/account/mod.rs
@@ -21,7 +21,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_and_delete() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
 
         // Insert
@@ -56,7 +56,7 @@ mod tests {
 
     #[tokio::test]
     async fn update() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let mut account = Account::default();
 
         // Insert

--- a/scheduler/crates/infra/src/repos/account/postgres.rs
+++ b/scheduler/crates/infra/src/repos/account/postgres.rs
@@ -1,3 +1,5 @@
+use std::convert::{TryFrom, TryInto};
+
 use nettu_scheduler_domain::{Account, PEMKey, ID};
 use serde_json::Value;
 use sqlx::{
@@ -28,18 +30,21 @@ pub struct AccountRaw {
     settings: Value,
 }
 
-impl From<AccountRaw> for Account {
-    fn from(e: AccountRaw) -> Self {
-        Self {
+impl TryFrom<AccountRaw> for Account {
+    type Error = anyhow::Error;
+
+    fn try_from(e: AccountRaw) -> anyhow::Result<Self> {
+        let pem_key = if let Some(public_jwt_key) = e.public_jwt_key {
+            Some(PEMKey::new(public_jwt_key)?)
+        } else {
+            None
+        };
+        Ok(Self {
             id: e.account_uid.into(),
             secret_api_key: e.secret_api_key,
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            public_jwt_key: e.public_jwt_key.map(|key| PEMKey::new(key).unwrap()),
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            settings: serde_json::from_value(e.settings).unwrap(),
-        }
+            public_jwt_key: pem_key,
+            settings: serde_json::from_value(e.settings)?,
+        })
     }
 }
 
@@ -59,12 +64,11 @@ impl IAccountRepo for PostgresAccountRepo {
         )
         .execute(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to insert account: {:?}. DB returned error: {:?}",
                 account, e
             );
-            e
         })?;
         Ok(())
     }
@@ -86,19 +90,18 @@ impl IAccountRepo for PostgresAccountRepo {
         )
         .execute(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to save account: {:?}. DB returned error: {:?}",
                 account, e
             );
-            e
         })?;
         Ok(())
     }
 
     #[instrument]
-    async fn find(&self, account_id: &ID) -> Option<Account> {
-        let res: Option<AccountRaw> = sqlx::query_as!(
+    async fn find(&self, account_id: &ID) -> anyhow::Result<Option<Account>> {
+        sqlx::query_as!(
             AccountRaw,
             r#"
             SELECT * FROM accounts
@@ -108,15 +111,14 @@ impl IAccountRepo for PostgresAccountRepo {
         )
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find account with id: {:?} failed. DB returned error: {:?}",
                 account_id, e
             );
-            e
-        })
-        .ok()?;
-        res.map(|account| account.into())
+        })?
+        .map(|res| res.try_into())
+        .transpose()
     }
 
     #[instrument]
@@ -135,20 +137,23 @@ impl IAccountRepo for PostgresAccountRepo {
         )
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find accounts with ids: {:?} failed. DB returned error: {:?}",
                 accounts_ids, e
             );
-            e
         })?;
 
-        Ok(accounts_raw.into_iter().map(|acc| acc.into()).collect())
+        // Use map and try_into for each account and collect the results
+        accounts_raw
+            .into_iter()
+            .map(|acc| acc.try_into()) // Apply try_into to each AccountRaw
+            .collect::<Result<Vec<Account>, _>>() // Collect into Result<Vec<Account>, _>
     }
 
     #[instrument]
-    async fn delete(&self, account_id: &ID) -> Option<Account> {
-        let res: Option<AccountRaw> = sqlx::query_as!(
+    async fn delete(&self, account_id: &ID) -> anyhow::Result<Option<Account>> {
+        sqlx::query_as!(
             AccountRaw,
             "
             DELETE FROM accounts
@@ -159,20 +164,19 @@ impl IAccountRepo for PostgresAccountRepo {
         )
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Delete account with id: {:?} failed. DB returned error: {:?}",
                 account_id, e
             );
-            e
-        })
-        .ok()?;
-        res.map(|acc| acc.into())
+        })?
+        .map(|res| res.try_into())
+        .transpose()
     }
 
     #[instrument]
-    async fn find_by_apikey(&self, api_key: &str) -> Option<Account> {
-        let res: Option<AccountRaw> = sqlx::query_as!(
+    async fn find_by_apikey(&self, api_key: &str) -> anyhow::Result<Option<Account>> {
+        sqlx::query_as!(
             AccountRaw,
             "
             SELECT * FROM accounts
@@ -182,15 +186,13 @@ impl IAccountRepo for PostgresAccountRepo {
         )
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find account with api_key: {:?} failed. DB returned error: {:?}",
                 api_key, e
             );
-            e
-        })
-        .ok()?;
-
-        res.map(|acc| acc.into())
+        })?
+        .map(|res| res.try_into())
+        .transpose()
     }
 }

--- a/scheduler/crates/infra/src/repos/account/postgres.rs
+++ b/scheduler/crates/infra/src/repos/account/postgres.rs
@@ -33,7 +33,11 @@ impl From<AccountRaw> for Account {
         Self {
             id: e.account_uid.into(),
             secret_api_key: e.secret_api_key,
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             public_jwt_key: e.public_jwt_key.map(|key| PEMKey::new(key).unwrap()),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             settings: serde_json::from_value(e.settings).unwrap(),
         }
     }

--- a/scheduler/crates/infra/src/repos/account_integrations/mod.rs
+++ b/scheduler/crates/infra/src/repos/account_integrations/mod.rs
@@ -18,7 +18,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_account_integrations() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let account = Account::new();
         ctx.repos

--- a/scheduler/crates/infra/src/repos/account_integrations/postgres.rs
+++ b/scheduler/crates/infra/src/repos/account_integrations/postgres.rs
@@ -54,12 +54,11 @@ impl IAccountIntegrationRepo for PostgresAccountIntegrationRepo {
         )
         .execute(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to insert account integration: {:?}. DB returned error: {:?}",
                 integration, e
             );
-            e
         })?;
         Ok(())
     }
@@ -76,12 +75,11 @@ impl IAccountIntegrationRepo for PostgresAccountIntegrationRepo {
         )
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to query account integrations for account: {:?}. DB returned error: {:?}",
                 account_id, e
             );
-            e
         })?;
         Ok(integrations.into_iter().map(|i| i.into()).collect())
     }

--- a/scheduler/crates/infra/src/repos/calendar/mod.rs
+++ b/scheduler/crates/infra/src/repos/calendar/mod.rs
@@ -24,7 +24,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_and_delete() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);
@@ -50,7 +50,7 @@ mod tests {
 
     #[tokio::test]
     async fn update() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);
@@ -73,7 +73,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_by_user() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);

--- a/scheduler/crates/infra/src/repos/calendar/mod.rs
+++ b/scheduler/crates/infra/src/repos/calendar/mod.rs
@@ -9,11 +9,11 @@ use super::shared::query_structs::MetadataFindQuery;
 pub trait ICalendarRepo: Send + Sync {
     async fn insert(&self, calendar: &Calendar) -> anyhow::Result<()>;
     async fn save(&self, calendar: &Calendar) -> anyhow::Result<()>;
-    async fn find(&self, calendar_id: &ID) -> Option<Calendar>;
-    async fn find_multiple(&self, calendar_ids: Vec<&ID>) -> Vec<Calendar>;
-    async fn find_by_user(&self, user_id: &ID) -> Vec<Calendar>;
+    async fn find(&self, calendar_id: &ID) -> anyhow::Result<Option<Calendar>>;
+    async fn find_multiple(&self, calendar_ids: Vec<&ID>) -> anyhow::Result<Vec<Calendar>>;
+    async fn find_by_user(&self, user_id: &ID) -> anyhow::Result<Vec<Calendar>>;
     async fn delete(&self, calendar_id: &ID) -> anyhow::Result<()>;
-    async fn find_by_metadata(&self, query: MetadataFindQuery) -> Vec<Calendar>;
+    async fn find_by_metadata(&self, query: MetadataFindQuery) -> anyhow::Result<Vec<Calendar>>;
 }
 
 #[cfg(test)]
@@ -35,9 +35,15 @@ mod tests {
         assert!(ctx.repos.calendars.insert(&calendar).await.is_ok());
 
         // Different find methods
-        let res = ctx.repos.calendars.find(&calendar.id).await.unwrap();
+        let res = ctx
+            .repos
+            .calendars
+            .find(&calendar.id)
+            .await
+            .unwrap()
+            .unwrap();
         assert!(res.eq(&calendar));
-        let res = ctx.repos.calendars.find_by_user(&user.id).await;
+        let res = ctx.repos.calendars.find_by_user(&user.id).await.unwrap();
         assert!(res[0].eq(&calendar));
 
         // Delete
@@ -45,7 +51,13 @@ mod tests {
         assert!(res.is_ok());
 
         // Find
-        assert!(ctx.repos.calendars.find(&calendar.id).await.is_none());
+        assert!(ctx
+            .repos
+            .calendars
+            .find(&calendar.id)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]
@@ -64,7 +76,13 @@ mod tests {
         // Save
         assert!(ctx.repos.calendars.save(&calendar).await.is_ok());
 
-        let updated_calendar = ctx.repos.calendars.find(&calendar.id).await.unwrap();
+        let updated_calendar = ctx
+            .repos
+            .calendars
+            .find(&calendar.id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(
             updated_calendar.settings.week_start,
             calendar.settings.week_start
@@ -84,10 +102,16 @@ mod tests {
         assert!(ctx.repos.calendars.insert(&calendar).await.is_ok());
 
         // Delete
-        let res = ctx.repos.users.delete(&user.id).await;
+        let res = ctx.repos.users.delete(&user.id).await.unwrap();
         assert!(res.is_some());
 
         // Find
-        assert!(ctx.repos.calendars.find(&calendar.id).await.is_none());
+        assert!(ctx
+            .repos
+            .calendars
+            .find(&calendar.id)
+            .await
+            .unwrap()
+            .is_none());
     }
 }

--- a/scheduler/crates/infra/src/repos/calendar/postgres.rs
+++ b/scheduler/crates/infra/src/repos/calendar/postgres.rs
@@ -36,7 +36,11 @@ impl From<CalendarRaw> for Calendar {
             id: e.calendar_uid.into(),
             user_id: e.user_uid.into(),
             account_id: e.account_uid.into(),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             settings: serde_json::from_value(e.settings).unwrap(),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             metadata: serde_json::from_value(e.metadata).unwrap(),
         }
     }

--- a/scheduler/crates/infra/src/repos/calendar/postgres.rs
+++ b/scheduler/crates/infra/src/repos/calendar/postgres.rs
@@ -1,3 +1,5 @@
+use std::convert::{TryFrom, TryInto};
+
 use nettu_scheduler_domain::{Calendar, ID};
 use serde_json::Value;
 use sqlx::{
@@ -30,19 +32,17 @@ struct CalendarRaw {
     metadata: Value,
 }
 
-impl From<CalendarRaw> for Calendar {
-    fn from(e: CalendarRaw) -> Self {
-        Self {
+impl TryFrom<CalendarRaw> for Calendar {
+    type Error = anyhow::Error;
+
+    fn try_from(e: CalendarRaw) -> anyhow::Result<Self> {
+        Ok(Self {
             id: e.calendar_uid.into(),
             user_id: e.user_uid.into(),
             account_id: e.account_uid.into(),
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            settings: serde_json::from_value(e.settings).unwrap(),
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            metadata: serde_json::from_value(e.metadata).unwrap(),
-        }
+            settings: serde_json::from_value(e.settings)?,
+            metadata: serde_json::from_value(e.metadata)?,
+        })
     }
 }
 
@@ -88,19 +88,18 @@ impl ICalendarRepo for PostgresCalendarRepo {
         )
         .execute(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to save calendar: {:?}. DB returned error: {:?}",
                 calendar, e
             );
-            e
         })?;
         Ok(())
     }
 
     #[instrument]
-    async fn find(&self, calendar_id: &ID) -> Option<Calendar> {
-        let res: Option<CalendarRaw> = sqlx::query_as!(
+    async fn find(&self, calendar_id: &ID) -> anyhow::Result<Option<Calendar>> {
+        sqlx::query_as!(
             CalendarRaw,
             r#"
             SELECT c.*, u.account_uid FROM calendars AS c
@@ -112,25 +111,23 @@ impl ICalendarRepo for PostgresCalendarRepo {
         )
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find calendar with id: {:?} failed. DB returned error: {:?}",
                 calendar_id, e
             );
-            e
-        })
-        .ok()?;
-
-        res.map(|cal| cal.into())
+        })?
+        .map(|cal| cal.try_into())
+        .transpose()
     }
 
     #[instrument]
-    async fn find_multiple(&self, calendar_ids: Vec<&ID>) -> Vec<Calendar> {
+    async fn find_multiple(&self, calendar_ids: Vec<&ID>) -> anyhow::Result<Vec<Calendar>> {
         let calendar_ids: Vec<Uuid> = calendar_ids
             .into_iter()
             .map(|id| id.clone().into())
             .collect();
-        let calendars: Vec<CalendarRaw> = sqlx::query_as!(
+        sqlx::query_as!(
             CalendarRaw,
             r#"
             SELECT c.*, u.account_uid FROM calendars AS c
@@ -142,21 +139,20 @@ impl ICalendarRepo for PostgresCalendarRepo {
         )
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find calendars with ids: {:?} failed. DB returned error: {:?}",
                 calendar_ids, e
             );
-            e
-        })
-        .unwrap_or_default();
-
-        calendars.into_iter().map(|c| c.into()).collect()
+        })?
+        .into_iter()
+        .map(|c| c.try_into())
+        .collect()
     }
 
     #[instrument]
-    async fn find_by_user(&self, user_id: &ID) -> Vec<Calendar> {
-        let calendars: Vec<CalendarRaw> = sqlx::query_as!(
+    async fn find_by_user(&self, user_id: &ID) -> anyhow::Result<Vec<Calendar>> {
+        sqlx::query_as!(
             CalendarRaw,
             r#"
             SELECT c.*, u.account_uid FROM calendars AS c
@@ -168,16 +164,15 @@ impl ICalendarRepo for PostgresCalendarRepo {
         )
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find calendar by user id: {:?} failed. DB returned error: {:?}",
                 user_id, e
             );
-            e
-        })
-        .unwrap_or_default();
-
-        calendars.into_iter().map(|c| c.into()).collect()
+        })?
+        .into_iter()
+        .map(|c| c.try_into())
+        .collect()
     }
 
     #[instrument]
@@ -192,19 +187,18 @@ impl ICalendarRepo for PostgresCalendarRepo {
         .execute(&self.pool)
         .await
         .map(|_| ())
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Delete calendar with id: {:?} failed. DB returned error: {:?}",
                 calendar_id, e
             );
-
-            anyhow::Error::new(e)
-        })
+        })?;
+        Ok(())
     }
 
     #[instrument]
-    async fn find_by_metadata(&self, query: MetadataFindQuery) -> Vec<Calendar> {
-        let calendars: Vec<CalendarRaw> = sqlx::query_as!(
+    async fn find_by_metadata(&self, query: MetadataFindQuery) -> anyhow::Result<Vec<Calendar>> {
+        sqlx::query_as!(
             CalendarRaw,
             r#"
             SELECT c.*, u.account_uid FROM calendars AS c
@@ -221,15 +215,14 @@ impl ICalendarRepo for PostgresCalendarRepo {
         )
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find calendars by metadata: {:?} failed. DB returned error: {:?}",
                 query, e
             );
-            e
-        })
-        .unwrap_or_default();
-
-        calendars.into_iter().map(|c| c.into()).collect()
+        })?
+        .into_iter()
+        .map(|c| c.try_into())
+        .collect()
     }
 }

--- a/scheduler/crates/infra/src/repos/calendar_synced/mod.rs
+++ b/scheduler/crates/infra/src/repos/calendar_synced/mod.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_calendar_synced_repo() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let account = Account::new();
         ctx.repos

--- a/scheduler/crates/infra/src/repos/event/calendar_event/mod.rs
+++ b/scheduler/crates/infra/src/repos/event/calendar_event/mod.rs
@@ -85,7 +85,7 @@ mod tests {
     }
 
     async fn setup() -> TestContext {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);
@@ -443,7 +443,7 @@ mod tests {
 
     #[tokio::test]
     async fn find_most_recently_created_service_events() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
 
@@ -558,7 +558,7 @@ mod tests {
 
     #[tokio::test]
     async fn find_by_service_and_timespan() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
 

--- a/scheduler/crates/infra/src/repos/event/calendar_event/mod.rs
+++ b/scheduler/crates/infra/src/repos/event/calendar_event/mod.rs
@@ -16,7 +16,7 @@ pub struct MostRecentCreatedServiceEvents {
 pub trait IEventRepo: Send + Sync {
     async fn insert(&self, e: &CalendarEvent) -> anyhow::Result<()>;
     async fn save(&self, e: &CalendarEvent) -> anyhow::Result<()>;
-    async fn find(&self, event_id: &ID) -> Option<CalendarEvent>;
+    async fn find(&self, event_id: &ID) -> anyhow::Result<Option<CalendarEvent>>;
     async fn find_many(&self, event_ids: &[ID]) -> anyhow::Result<Vec<CalendarEvent>>;
     async fn find_by_calendar(
         &self,
@@ -32,24 +32,27 @@ pub trait IEventRepo: Send + Sync {
         &self,
         service_id: &ID,
         user_ids: &[ID],
-    ) -> Vec<MostRecentCreatedServiceEvents>;
+    ) -> anyhow::Result<Vec<MostRecentCreatedServiceEvents>>;
     async fn find_by_service(
         &self,
         service_id: &ID,
         user_ids: &[ID],
         min_time: DateTime<Utc>,
         max_time: DateTime<Utc>,
-    ) -> Vec<CalendarEvent>;
+    ) -> anyhow::Result<Vec<CalendarEvent>>;
     async fn find_user_service_events(
         &self,
         user_id: &ID,
         busy: bool,
         min_time: DateTime<Utc>,
         max_time: DateTime<Utc>,
-    ) -> Vec<CalendarEvent>;
+    ) -> anyhow::Result<Vec<CalendarEvent>>;
     async fn delete(&self, event_id: &ID) -> anyhow::Result<()>;
     async fn delete_by_service(&self, service_id: &ID) -> anyhow::Result<()>;
-    async fn find_by_metadata(&self, query: MetadataFindQuery) -> Vec<CalendarEvent>;
+    async fn find_by_metadata(
+        &self,
+        query: MetadataFindQuery,
+    ) -> anyhow::Result<Vec<CalendarEvent>>;
 }
 
 #[cfg(test)]
@@ -115,7 +118,7 @@ mod tests {
         assert!(ctx.repos.events.insert(&event).await.is_ok());
 
         // Different find methods
-        let get_event_res = ctx.repos.events.find(&event.id).await.unwrap();
+        let get_event_res = ctx.repos.events.find(&event.id).await.unwrap().unwrap();
         assert!(get_event_res.eq(&event));
         let get_event_res = ctx
             .repos
@@ -130,7 +133,7 @@ mod tests {
         assert!(delete_res.is_ok());
 
         // Find
-        assert!(ctx.repos.events.find(&event.id).await.is_none());
+        assert!(ctx.repos.events.find(&event.id).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -157,6 +160,7 @@ mod tests {
             .events
             .find(&event.id)
             .await
+            .unwrap()
             .expect("To be event")
             .eq(&event));
     }
@@ -175,10 +179,10 @@ mod tests {
         assert!(ctx.repos.events.insert(&event).await.is_ok());
 
         // Delete
-        assert!(ctx.repos.users.delete(&user.id).await.is_some());
+        assert!(ctx.repos.users.delete(&user.id).await.unwrap().is_some());
 
         // Find after delete
-        assert!(ctx.repos.events.find(&event.id).await.is_none());
+        assert!(ctx.repos.events.find(&event.id).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -198,7 +202,7 @@ mod tests {
         assert!(ctx.repos.calendars.delete(&calendar.id).await.is_ok());
 
         // Find after delete
-        assert!(ctx.repos.events.find(&event.id).await.is_none());
+        assert!(ctx.repos.events.find(&event.id).await.unwrap().is_none());
     }
 
     async fn generate_event_with_time(
@@ -531,7 +535,8 @@ mod tests {
                 &service.id,
                 &[user1.id.clone(), user2.id.clone(), user3.id.clone()],
             )
-            .await;
+            .await
+            .unwrap();
         assert_eq!(recent_service_events.len(), 3);
         let user1_recent_service_events = recent_service_events
             .iter()
@@ -735,7 +740,8 @@ mod tests {
                 DateTime::from_timestamp_millis(start_ts).unwrap(),
                 DateTime::from_timestamp_millis(end_ts).unwrap(),
             )
-            .await;
+            .await
+            .unwrap();
 
         assert_eq!(
             events_in_service_and_timespan.len(),
@@ -756,7 +762,8 @@ mod tests {
                 DateTime::from_timestamp_millis(start_ts).unwrap(),
                 DateTime::from_timestamp_millis(end_ts).unwrap(),
             )
-            .await;
+            .await
+            .unwrap();
         assert_eq!(events_in_service_with_no_users.len(), 0);
     }
 
@@ -808,7 +815,8 @@ mod tests {
                 DateTime::from_timestamp_millis(start_ts).unwrap(),
                 DateTime::from_timestamp_millis(end_ts).unwrap(),
             )
-            .await;
+            .await
+            .unwrap();
 
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].id, service_event.id);

--- a/scheduler/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/scheduler/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -59,10 +59,14 @@ struct EventRaw {
 impl From<EventRaw> for CalendarEvent {
     fn from(e: EventRaw) -> Self {
         let recurrence: Option<RRuleOptions> = match e.recurrence {
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             Some(json) => serde_json::from_value(json).unwrap(),
             None => None,
         };
         let reminders: Vec<CalendarEventReminder> = match e.reminders {
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             Some(json) => serde_json::from_value(json).unwrap(),
             None => Vec::new(),
         };
@@ -82,6 +86,8 @@ impl From<EventRaw> for CalendarEvent {
             exdates: e.exdates,
             reminders,
             service_id: e.service_uid.map(|id| id.into()),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             metadata: serde_json::from_value(e.metadata).unwrap(),
         }
     }

--- a/scheduler/crates/infra/src/repos/event/event_reminders_expansion_jobs/mod.rs
+++ b/scheduler/crates/infra/src/repos/event/event_reminders_expansion_jobs/mod.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[tokio::test]
     async fn crud() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);

--- a/scheduler/crates/infra/src/repos/event/event_reminders_expansion_jobs/mod.rs
+++ b/scheduler/crates/infra/src/repos/event/event_reminders_expansion_jobs/mod.rs
@@ -7,7 +7,10 @@ pub use postgres::PostgresEventReminderGenerationJobsRepo;
 #[async_trait::async_trait]
 pub trait IEventRemindersGenerationJobsRepo: Send + Sync {
     async fn bulk_insert(&self, jobs: &[EventRemindersExpansionJob]) -> anyhow::Result<()>;
-    async fn delete_all_before(&self, before: DateTime<Utc>) -> Vec<EventRemindersExpansionJob>;
+    async fn delete_all_before(
+        &self,
+        before: DateTime<Utc>,
+    ) -> anyhow::Result<Vec<EventRemindersExpansionJob>>;
 }
 
 #[cfg(test)]
@@ -110,7 +113,8 @@ mod tests {
             .repos
             .event_reminders_generation_jobs
             .delete_all_before(jobs[1].timestamp)
-            .await;
+            .await
+            .unwrap();
         assert_eq!(delete_res.len(), 2);
         assert_eq!(delete_res[0], jobs[0]);
         assert_eq!(delete_res[1], jobs[1]);

--- a/scheduler/crates/infra/src/repos/event/event_synced/mod.rs
+++ b/scheduler/crates/infra/src/repos/event/event_synced/mod.rs
@@ -27,7 +27,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_synced_repo() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let account = Account::new();
         ctx.repos

--- a/scheduler/crates/infra/src/repos/event/reminder/mod.rs
+++ b/scheduler/crates/infra/src/repos/event/reminder/mod.rs
@@ -9,7 +9,7 @@ pub trait IReminderRepo: Send + Sync {
     async fn bulk_insert(&self, reminders: &[Reminder]) -> anyhow::Result<()>;
     async fn init_version(&self, event_id: &ID) -> anyhow::Result<i64>;
     async fn inc_version(&self, event_id: &ID) -> anyhow::Result<i64>;
-    async fn delete_all_before(&self, before: DateTime<Utc>) -> Vec<Reminder>;
+    async fn delete_all_before(&self, before: DateTime<Utc>) -> anyhow::Result<Vec<Reminder>>;
 }
 
 #[cfg(test)]
@@ -82,7 +82,8 @@ mod tests {
             .repos
             .reminders
             .delete_all_before(reminders[1].remind_at)
-            .await;
+            .await
+            .unwrap();
         assert_eq!(delete_res.len(), 2);
         assert_eq!(delete_res[0], reminders[0]);
         assert_eq!(delete_res[1], reminders[1]);
@@ -99,7 +100,8 @@ mod tests {
             .repos
             .reminders
             .delete_all_before(reminders[3].remind_at)
-            .await;
+            .await
+            .unwrap();
         // Reminders has been deleted because there is a new version now
         assert_eq!(delete_res.len(), 0);
     }

--- a/scheduler/crates/infra/src/repos/event/reminder/mod.rs
+++ b/scheduler/crates/infra/src/repos/event/reminder/mod.rs
@@ -21,7 +21,7 @@ mod tests {
 
     #[tokio::test]
     async fn crud() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);

--- a/scheduler/crates/infra/src/repos/mod.rs
+++ b/scheduler/crates/infra/src/repos/mod.rs
@@ -64,15 +64,12 @@ pub struct Repos {
 }
 
 impl Repos {
-    pub async fn create_postgres(
-        connection_string: &str,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn create_postgres(connection_string: &str) -> anyhow::Result<Self> {
         info!("DB CHECKING CONNECTION ...");
         let pool = PgPoolOptions::new()
             .max_connections(5)
             .connect(connection_string)
-            .await
-            .expect("TO CONNECT TO POSTGRES");
+            .await?;
         info!("DB CHECKING CONNECTION ... [done]");
 
         if std::env::var("NETTU_SKIP_MIGRATION").is_err() {

--- a/scheduler/crates/infra/src/repos/reservation/mod.rs
+++ b/scheduler/crates/infra/src/repos/reservation/mod.rs
@@ -20,7 +20,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_reservations_repo() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let account = Account::new();
         ctx.repos
@@ -85,7 +85,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_reservation() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let account = Account::new();
         ctx.repos

--- a/scheduler/crates/infra/src/repos/schedule/mod.rs
+++ b/scheduler/crates/infra/src/repos/schedule/mod.rs
@@ -25,7 +25,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_and_delete() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos
             .accounts
@@ -64,7 +64,7 @@ mod tests {
 
     #[tokio::test]
     async fn update() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos
             .accounts

--- a/scheduler/crates/infra/src/repos/schedule/mod.rs
+++ b/scheduler/crates/infra/src/repos/schedule/mod.rs
@@ -9,11 +9,11 @@ use crate::MetadataFindQuery;
 pub trait IScheduleRepo: Send + Sync {
     async fn insert(&self, schedule: &Schedule) -> anyhow::Result<()>;
     async fn save(&self, schedule: &Schedule) -> anyhow::Result<()>;
-    async fn find(&self, schedule_id: &ID) -> Option<Schedule>;
-    async fn find_many(&self, schedule_ids: &[ID]) -> Vec<Schedule>;
-    async fn find_by_user(&self, user_id: &ID) -> Vec<Schedule>;
+    async fn find(&self, schedule_id: &ID) -> anyhow::Result<Option<Schedule>>;
+    async fn find_many(&self, schedule_ids: &[ID]) -> anyhow::Result<Vec<Schedule>>;
+    async fn find_by_user(&self, user_id: &ID) -> anyhow::Result<Vec<Schedule>>;
     async fn delete(&self, schedule_id: &ID) -> anyhow::Result<()>;
-    async fn find_by_metadata(&self, query: MetadataFindQuery) -> Vec<Schedule>;
+    async fn find_by_metadata(&self, query: MetadataFindQuery) -> anyhow::Result<Vec<Schedule>>;
 }
 
 #[cfg(test)]
@@ -41,9 +41,20 @@ mod tests {
         assert!(ctx.repos.schedules.insert(&schedule).await.is_ok());
 
         // Different find methods
-        let res = ctx.repos.schedules.find(&schedule.id).await.unwrap();
+        let res = ctx
+            .repos
+            .schedules
+            .find(&schedule.id)
+            .await
+            .unwrap()
+            .unwrap();
         assert!(res.eq(&schedule));
-        let res = ctx.repos.schedules.find_many(&[schedule.id.clone()]).await;
+        let res = ctx
+            .repos
+            .schedules
+            .find_many(&[schedule.id.clone()])
+            .await
+            .unwrap();
         assert_eq!(res.len(), 1);
         assert!(res[0].eq(&schedule));
 
@@ -52,14 +63,26 @@ mod tests {
         assert!(res.is_ok());
 
         // Find
-        assert!(ctx.repos.schedules.find(&schedule.id).await.is_none());
+        assert!(ctx
+            .repos
+            .schedules
+            .find(&schedule.id)
+            .await
+            .unwrap()
+            .is_none());
 
         // Insert again
         assert!(ctx.repos.schedules.insert(&schedule).await.is_ok());
 
         // Delete by user
         ctx.repos.users.delete(&user.id).await.expect("Delete user");
-        assert!(ctx.repos.schedules.find(&schedule.id).await.is_none());
+        assert!(ctx
+            .repos
+            .schedules
+            .find(&schedule.id)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]
@@ -91,6 +114,7 @@ mod tests {
             .schedules
             .find(&schedule.id)
             .await
+            .unwrap()
             .unwrap()
             .rules
             .is_empty());

--- a/scheduler/crates/infra/src/repos/schedule/postgres.rs
+++ b/scheduler/crates/infra/src/repos/schedule/postgres.rs
@@ -39,6 +39,8 @@ impl From<ScheduleRaw> for Schedule {
             account_id: e.account_uid.into(),
             rules: serde_json::from_value(e.rules).unwrap_or_default(),
             timezone: e.timezone.parse().unwrap_or(chrono_tz::UTC),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             metadata: serde_json::from_value(e.metadata).unwrap(),
         }
     }

--- a/scheduler/crates/infra/src/repos/service/mod.rs
+++ b/scheduler/crates/infra/src/repos/service/mod.rs
@@ -9,10 +9,10 @@ use super::shared::query_structs::MetadataFindQuery;
 pub trait IServiceRepo: Send + Sync {
     async fn insert(&self, service: &Service) -> anyhow::Result<()>;
     async fn save(&self, service: &Service) -> anyhow::Result<()>;
-    async fn find(&self, service_id: &ID) -> Option<Service>;
-    async fn find_with_users(&self, service_id: &ID) -> Option<ServiceWithUsers>;
+    async fn find(&self, service_id: &ID) -> anyhow::Result<Option<Service>>;
+    async fn find_with_users(&self, service_id: &ID) -> anyhow::Result<Option<ServiceWithUsers>>;
     async fn delete(&self, service_id: &ID) -> anyhow::Result<()>;
-    async fn find_by_metadata(&self, query: MetadataFindQuery) -> Vec<Service>;
+    async fn find_by_metadata(&self, query: MetadataFindQuery) -> anyhow::Result<Vec<Service>>;
 }
 
 #[cfg(test)]
@@ -41,6 +41,7 @@ mod tests {
             .services
             .find(&service.id)
             .await
+            .unwrap()
             .expect("To get service");
 
         let user = User::new(account.id.clone(), None);
@@ -64,6 +65,7 @@ mod tests {
             .services
             .find_with_users(&service.id)
             .await
+            .unwrap()
             .expect("To get service");
         assert_eq!(
             *service.metadata.inner.get("foo").unwrap(),
@@ -82,6 +84,7 @@ mod tests {
             .services
             .find_with_users(&service.id)
             .await
+            .unwrap()
             .expect("To get service");
         assert!(service.users.is_empty());
 
@@ -91,6 +94,12 @@ mod tests {
             .await
             .expect("To delete service");
 
-        assert!(ctx.repos.services.find(&service.id).await.is_none());
+        assert!(ctx
+            .repos
+            .services
+            .find(&service.id)
+            .await
+            .unwrap()
+            .is_none());
     }
 }

--- a/scheduler/crates/infra/src/repos/service/mod.rs
+++ b/scheduler/crates/infra/src/repos/service/mod.rs
@@ -23,7 +23,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_and_delete() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos
             .accounts

--- a/scheduler/crates/infra/src/repos/service/postgres.rs
+++ b/scheduler/crates/infra/src/repos/service/postgres.rs
@@ -43,7 +43,11 @@ impl From<ServiceRaw> for Service {
         Self {
             id: e.service_uid.into(),
             account_id: e.account_uid.into(),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             multi_person: serde_json::from_value(e.multi_person).unwrap(),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             metadata: serde_json::from_value(e.metadata).unwrap(),
         }
     }
@@ -59,7 +63,11 @@ impl From<ServiceWithUsersRaw> for ServiceWithUsers {
             id: e.service_uid.into(),
             account_id: e.account_uid.into(),
             users: users.into_iter().map(|u| u.into()).collect(),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             multi_person: serde_json::from_value(e.multi_person).unwrap(),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             metadata: serde_json::from_value(e.metadata).unwrap(),
         }
     }

--- a/scheduler/crates/infra/src/repos/service/postgres.rs
+++ b/scheduler/crates/infra/src/repos/service/postgres.rs
@@ -1,3 +1,5 @@
+use std::convert::{TryFrom, TryInto};
+
 use nettu_scheduler_domain::{Service, ServiceWithUsers, ID};
 use serde_json::Value;
 use sqlx::{
@@ -38,38 +40,32 @@ struct ServiceWithUsersRaw {
     metadata: Value,
 }
 
-impl From<ServiceRaw> for Service {
-    fn from(e: ServiceRaw) -> Self {
-        Self {
+impl TryFrom<ServiceRaw> for Service {
+    type Error = anyhow::Error;
+    fn try_from(e: ServiceRaw) -> anyhow::Result<Self> {
+        Ok(Self {
             id: e.service_uid.into(),
             account_id: e.account_uid.into(),
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            multi_person: serde_json::from_value(e.multi_person).unwrap(),
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            metadata: serde_json::from_value(e.metadata).unwrap(),
-        }
+            multi_person: serde_json::from_value(e.multi_person)?,
+            metadata: serde_json::from_value(e.metadata)?,
+        })
     }
 }
 
-impl From<ServiceWithUsersRaw> for ServiceWithUsers {
-    fn from(e: ServiceWithUsersRaw) -> Self {
+impl TryFrom<ServiceWithUsersRaw> for ServiceWithUsers {
+    type Error = anyhow::Error;
+    fn try_from(e: ServiceWithUsersRaw) -> anyhow::Result<Self> {
         let users: Vec<ServiceUserRaw> = match e.users {
             Some(json) => serde_json::from_value(json).unwrap_or_default(),
             None => Vec::new(),
         };
-        Self {
+        Ok(Self {
             id: e.service_uid.into(),
             account_id: e.account_uid.into(),
             users: users.into_iter().map(|u| u.into()).collect(),
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            multi_person: serde_json::from_value(e.multi_person).unwrap(),
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            metadata: serde_json::from_value(e.metadata).unwrap(),
-        }
+            multi_person: serde_json::from_value(e.multi_person)?,
+            metadata: serde_json::from_value(e.metadata)?,
+        })
     }
 }
 
@@ -89,12 +85,11 @@ impl IServiceRepo for PostgresServiceRepo {
         )
         .execute(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to insert service: {:?}. DB returned error: {:?}",
                 service, e
             );
-            e
         })?;
 
         Ok(())
@@ -115,20 +110,19 @@ impl IServiceRepo for PostgresServiceRepo {
         )
         .execute(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to save service: {:?}. DB returned error: {:?}",
                 service, e
             );
-            e
         })?;
 
         Ok(())
     }
 
     #[instrument]
-    async fn find(&self, service_id: &ID) -> Option<Service> {
-        let res: Option<ServiceRaw> = sqlx::query_as!(
+    async fn find(&self, service_id: &ID) -> anyhow::Result<Option<Service>> {
+        sqlx::query_as!(
             ServiceRaw,
             r#"
             SELECT * FROM services AS s
@@ -138,21 +132,20 @@ impl IServiceRepo for PostgresServiceRepo {
         )
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find service with id: {:?} failed. DB returned error: {:?}",
                 service_id, e
             );
-            e
-        })
-        .ok()?;
-
-        res.map(|service| service.into())
+        })?
+        .map(|service| service.try_into())
+        .transpose()
     }
 
     #[instrument]
-    async fn find_with_users(&self, service_id: &ID) -> Option<ServiceWithUsers> {
-        let res: Option<ServiceWithUsersRaw> = sqlx::query_as(
+    async fn find_with_users(&self, service_id: &ID) -> anyhow::Result<Option<ServiceWithUsers>> {
+        sqlx::query_as!(
+            ServiceWithUsersRaw,
             r#"
             SELECT s.*, jsonb_agg((su.*)) AS users FROM services AS s
             LEFT JOIN service_users AS su
@@ -160,20 +153,18 @@ impl IServiceRepo for PostgresServiceRepo {
             WHERE s.service_uid = $1
             GROUP BY s.service_uid
             "#,
+            service_id.as_ref()
         )
-        .bind(service_id.as_ref())
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find service with id: {:?} failed. DB returned error: {:?}",
                 service_id, e
             );
-            e
-        })
-        .ok()?;
-
-        res.map(|service| service.into())
+        })?
+        .map(|service| service.try_into())
+        .transpose()
     }
 
     #[instrument]
@@ -187,19 +178,19 @@ impl IServiceRepo for PostgresServiceRepo {
         )
         .execute(&self.pool)
         .await
-        .map(|_| ())
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Delete service with id: {:?} failed. DB returned error: {:?}",
                 service_id, e
             );
-            anyhow::Error::new(e)
         })
+        .map_err(Into::into)
+        .map(|_| ())
     }
 
     #[instrument]
-    async fn find_by_metadata(&self, query: MetadataFindQuery) -> Vec<Service> {
-        let services: Vec<ServiceRaw> = sqlx::query_as!(
+    async fn find_by_metadata(&self, query: MetadataFindQuery) -> anyhow::Result<Vec<Service>> {
+        sqlx::query_as!(
             ServiceRaw,
             r#"
             SELECT * FROM services AS s
@@ -214,15 +205,14 @@ impl IServiceRepo for PostgresServiceRepo {
         )
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find services by metadata: {:?} failed. DB returned error: {:?}",
                 query, e
             );
-            e
-        })
-        .unwrap_or_default();
-
-        services.into_iter().map(|s| s.into()).collect()
+        })?
+        .into_iter()
+        .map(|s| s.try_into())
+        .collect()
     }
 }

--- a/scheduler/crates/infra/src/repos/service_user/mod.rs
+++ b/scheduler/crates/infra/src/repos/service_user/mod.rs
@@ -28,7 +28,7 @@ mod tests {
 
     #[tokio::test]
     async fn crud() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
         let account = Account::default();
         ctx.repos.accounts.insert(&account).await.unwrap();
         let user = User::new(account.id.clone(), None);

--- a/scheduler/crates/infra/src/repos/service_user/mod.rs
+++ b/scheduler/crates/infra/src/repos/service_user/mod.rs
@@ -7,8 +7,8 @@ pub use postgres::{PostgresServiceUserRepo, ServiceUserRaw};
 pub trait IServiceUserRepo: Send + Sync {
     async fn insert(&self, user: &ServiceResource) -> anyhow::Result<()>;
     async fn save(&self, user: &ServiceResource) -> anyhow::Result<()>;
-    async fn find(&self, service_id: &ID, user_id: &ID) -> Option<ServiceResource>;
-    async fn find_by_user(&self, user_id: &ID) -> Vec<ServiceResource>;
+    async fn find(&self, service_id: &ID, user_id: &ID) -> anyhow::Result<Option<ServiceResource>>;
+    async fn find_by_user(&self, user_id: &ID) -> anyhow::Result<Vec<ServiceResource>>;
     async fn delete(&self, service_id: &ID, user_uid: &ID) -> anyhow::Result<()>;
 }
 
@@ -47,11 +47,17 @@ mod tests {
             .service_users
             .find(&service.id, &user.id)
             .await
+            .unwrap()
             .unwrap();
         assert!(res.eq(&service_user));
 
         // Find by user
-        let find_by_user = ctx.repos.service_users.find_by_user(&user.id).await;
+        let find_by_user = ctx
+            .repos
+            .service_users
+            .find_by_user(&user.id)
+            .await
+            .unwrap();
         assert_eq!(find_by_user.len(), 1);
         assert!(find_by_user[0].eq(&service_user));
 
@@ -69,6 +75,7 @@ mod tests {
             .service_users
             .find(&service.id, &user.id)
             .await
+            .unwrap()
             .unwrap();
         assert_eq!(updated_service_user.buffer_after, service_user.buffer_after);
         assert_eq!(updated_service_user.user_id, service_user.user_id);
@@ -88,6 +95,7 @@ mod tests {
             .service_users
             .find(&service.id, &user.id)
             .await
+            .unwrap()
             .is_none());
     }
 }

--- a/scheduler/crates/infra/src/repos/service_user_busy_calendars/mod.rs
+++ b/scheduler/crates/infra/src/repos/service_user_busy_calendars/mod.rs
@@ -47,7 +47,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_service_user_busy_calendars() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let account = Account::new();
         ctx.repos

--- a/scheduler/crates/infra/src/repos/service_user_busy_calendars/postgres.rs
+++ b/scheduler/crates/infra/src/repos/service_user_busy_calendars/postgres.rs
@@ -26,6 +26,8 @@ impl From<BusyCalendarRaw> for BusyCalendar {
         match &e.provider[..] {
             "google" => BusyCalendar::Google(e.calendar_id),
             "outlook" => BusyCalendar::Outlook(e.calendar_id),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             "nettu" => BusyCalendar::Nettu(e.calendar_id.parse().unwrap()),
             _ => unreachable!("Invalid provider"),
         }

--- a/scheduler/crates/infra/src/repos/user/mod.rs
+++ b/scheduler/crates/infra/src/repos/user/mod.rs
@@ -25,7 +25,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_metadata_query() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let account = Account::new();
         ctx.repos
@@ -67,7 +67,7 @@ mod tests {
 
     // #[tokio::test]
     // async fn test_google_integration_revoke() {
-    //     let ctx = setup_context().await;
+    //     let ctx = setup_context().await.unwrap();
     //     let account_id = ID::default();
     //     let mut user = User::new(account_id.clone());
     //     user.integrations = vec![IntegrationProvider::Google(UserGoogleIntegrationData {

--- a/scheduler/crates/infra/src/repos/user/postgres.rs
+++ b/scheduler/crates/infra/src/repos/user/postgres.rs
@@ -33,6 +33,8 @@ impl From<UserRaw> for User {
         Self {
             id: e.user_uid.into(),
             account_id: e.account_uid.into(),
+            // TODO: to fix
+            #[allow(clippy::unwrap_used)]
             metadata: serde_json::from_value(e.metadata).unwrap(),
         }
     }

--- a/scheduler/crates/infra/src/repos/user/postgres.rs
+++ b/scheduler/crates/infra/src/repos/user/postgres.rs
@@ -1,3 +1,5 @@
+use std::convert::{TryFrom, TryInto};
+
 use nettu_scheduler_domain::{User, ID};
 use serde_json::Value;
 use sqlx::{
@@ -28,15 +30,14 @@ struct UserRaw {
     metadata: Value,
 }
 
-impl From<UserRaw> for User {
-    fn from(e: UserRaw) -> Self {
-        Self {
+impl TryFrom<UserRaw> for User {
+    type Error = anyhow::Error;
+    fn try_from(e: UserRaw) -> anyhow::Result<Self> {
+        Ok(Self {
             id: e.user_uid.into(),
             account_id: e.account_uid.into(),
-            // TODO: to fix
-            #[allow(clippy::unwrap_used)]
-            metadata: serde_json::from_value(e.metadata).unwrap(),
-        }
+            metadata: serde_json::from_value(e.metadata)?,
+        })
     }
 }
 
@@ -55,12 +56,11 @@ impl IUserRepo for PostgresUserRepo {
         )
         .execute(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to insert user: {:?}. DB returned error: {:?}",
                 user, e
             );
-            e
         })?;
 
         Ok(())
@@ -81,18 +81,17 @@ impl IUserRepo for PostgresUserRepo {
         )
         .execute(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Unable to save user: {:?}. DB returned error: {:?}",
                 user, e
             );
-            e
         })?;
         Ok(())
     }
 
     #[instrument]
-    async fn delete(&self, user_id: &ID) -> Option<User> {
+    async fn delete(&self, user_id: &ID) -> anyhow::Result<Option<User>> {
         let res = sqlx::query_as!(
             UserRaw,
             r#"
@@ -104,20 +103,18 @@ impl IUserRepo for PostgresUserRepo {
         )
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Delete user with id: {} failed. DB returned error: {:?}",
                 user_id, e
             );
-            e
-        })
-        .ok()?;
+        })?;
 
-        res.map(|user| user.into())
+        res.map(|user| user.try_into()).transpose()
     }
 
     #[instrument]
-    async fn find(&self, user_id: &ID) -> Option<User> {
+    async fn find(&self, user_id: &ID) -> anyhow::Result<Option<User>> {
         let res = sqlx::query_as!(
             UserRaw,
             r#"
@@ -128,20 +125,18 @@ impl IUserRepo for PostgresUserRepo {
         )
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find user with user_id: {} failed. DB returned error: {:?}",
                 user_id, e
             );
-            e
-        })
-        .ok()?;
+        })?;
 
-        res.map(|user| user.into())
+        res.map(|user| user.try_into()).transpose()
     }
 
     #[instrument]
-    async fn find_many(&self, user_ids: &[ID]) -> Vec<User> {
+    async fn find_many(&self, user_ids: &[ID]) -> anyhow::Result<Vec<User>> {
         let user_ids = user_ids.iter().map(|id| *id.as_ref()).collect::<Vec<_>>();
 
         let users: Vec<UserRaw> = sqlx::query_as!(
@@ -154,20 +149,22 @@ impl IUserRepo for PostgresUserRepo {
         )
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find users with user_ids: {:?} failed. DB returned error: {:?}",
                 user_ids, e
             );
-            e
-        })
-        .unwrap_or_default();
+        })?;
 
-        users.into_iter().map(|u| u.into()).collect()
+        users.into_iter().map(|u| u.try_into()).collect()
     }
 
     #[instrument]
-    async fn find_by_account_id(&self, user_id: &ID, account_id: &ID) -> Option<User> {
+    async fn find_by_account_id(
+        &self,
+        user_id: &ID,
+        account_id: &ID,
+    ) -> anyhow::Result<Option<User>> {
         let res = sqlx::query_as!(
             UserRaw,
             r#"
@@ -180,20 +177,18 @@ impl IUserRepo for PostgresUserRepo {
         )
         .fetch_optional(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find user with user_id: {} failed. DB returned error: {:?}",
                 user_id, e
             );
-            e
-        })
-        .ok()?;
+        })?;
 
-        res.map(|user| user.into())
+        res.map(|user| user.try_into()).transpose()
     }
 
     #[instrument]
-    async fn find_by_metadata(&self, query: MetadataFindQuery) -> Vec<User> {
+    async fn find_by_metadata(&self, query: MetadataFindQuery) -> anyhow::Result<Vec<User>> {
         let users: Vec<UserRaw> = sqlx::query_as!(
             UserRaw,
             r#"
@@ -209,15 +204,13 @@ impl IUserRepo for PostgresUserRepo {
         )
         .fetch_all(&self.pool)
         .await
-        .map_err(|e| {
+        .inspect_err(|e| {
             error!(
                 "Find users by metadata: {:?} failed. DB returned error: {:?}",
                 query, e
             );
-            e
-        })
-        .unwrap_or_default();
+        })?;
 
-        users.into_iter().map(|u| u.into()).collect()
+        users.into_iter().map(|u| u.try_into()).collect()
     }
 }

--- a/scheduler/crates/infra/src/repos/user_integrations/mod.rs
+++ b/scheduler/crates/infra/src/repos/user_integrations/mod.rs
@@ -25,7 +25,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_user_integrations() {
-        let ctx = setup_context().await;
+        let ctx = setup_context().await.unwrap();
 
         let account = Account::new();
         ctx.repos

--- a/scheduler/crates/infra/src/services/google_calendar/calendar_api.rs
+++ b/scheduler/crates/infra/src/services/google_calendar/calendar_api.rs
@@ -182,7 +182,7 @@ impl GoogleCalendarRestApi {
     ) -> anyhow::Result<T> {
         match self
             .client
-            .put(&format!("{}/{}", GOOGLE_API_BASE_URL, path))
+            .put(format!("{}/{}", GOOGLE_API_BASE_URL, path))
             .header("authorization", format!("Bearer {}", self.access_token))
             .json(body)
             .send()
@@ -212,7 +212,7 @@ impl GoogleCalendarRestApi {
     ) -> anyhow::Result<T> {
         match self
             .client
-            .post(&format!("{}/{}", GOOGLE_API_BASE_URL, path))
+            .post(format!("{}/{}", GOOGLE_API_BASE_URL, path))
             .header("authorization", format!("Bearer {}", self.access_token))
             .json(body)
             .send()
@@ -238,7 +238,7 @@ impl GoogleCalendarRestApi {
     async fn get<T: for<'de> Deserialize<'de>>(&self, path: String) -> anyhow::Result<T> {
         match self
             .client
-            .get(&format!("{}/{}", GOOGLE_API_BASE_URL, path))
+            .get(format!("{}/{}", GOOGLE_API_BASE_URL, path))
             .header("authorization", format!("Bearer {}", self.access_token))
             .send()
             .await
@@ -263,7 +263,7 @@ impl GoogleCalendarRestApi {
     async fn delete<T: for<'de> Deserialize<'de>>(&self, path: String) -> anyhow::Result<T> {
         match self
             .client
-            .delete(&format!("{}/{}", GOOGLE_API_BASE_URL, path))
+            .delete(format!("{}/{}", GOOGLE_API_BASE_URL, path))
             .header("authorization", format!("Bearer {}", self.access_token))
             .send()
             .await

--- a/scheduler/crates/infra/src/services/google_calendar/mod.rs
+++ b/scheduler/crates/infra/src/services/google_calendar/mod.rs
@@ -58,9 +58,13 @@ impl GoogleCalendarProvider {
             for (_, calendar_busy) in res.calendars {
                 for instance in calendar_busy.busy {
                     let instance = EventInstance {
+                        // TODO: to fix
+                        #[allow(clippy::unwrap_used)]
                         start_time: DateTime::parse_from_rfc3339(&instance.start.to_string())
                             .unwrap()
                             .with_timezone(&Utc),
+                        // TODO: to fix
+                        #[allow(clippy::unwrap_used)]
                         end_time: DateTime::parse_from_rfc3339(&instance.end.to_string())
                             .unwrap()
                             .with_timezone(&Utc),

--- a/scheduler/crates/infra/src/services/outlook_calendar/calendar_api.rs
+++ b/scheduler/crates/infra/src/services/outlook_calendar/calendar_api.rs
@@ -287,9 +287,12 @@ impl OutlookCalendarRestApi {
                     .filter(|e| matches!(e.show_as, OutlookCalendarEventShowAs::Busy))
                     .map(|e| EventInstance {
                         busy: true,
-                        // TODO: handle unwrap
+                        // TODO: to fix
+                        #[allow(clippy::unwrap_used)]
                         start_time: DateTime::from_timestamp_millis(e.start.get_timestamp_millis())
                             .unwrap(),
+                        // TODO: to fix
+                        #[allow(clippy::unwrap_used)]
                         end_time: DateTime::from_timestamp_millis(e.end.get_timestamp_millis())
                             .unwrap(),
                     })

--- a/scheduler/crates/infra/src/services/outlook_calendar/calendar_api.rs
+++ b/scheduler/crates/infra/src/services/outlook_calendar/calendar_api.rs
@@ -117,7 +117,7 @@ impl OutlookCalendarRestApi {
     ) -> anyhow::Result<T> {
         match self
             .client
-            .put(&format!("{}/{}", API_BASE_URL, path))
+            .put(format!("{}/{}", API_BASE_URL, path))
             .header("authorization", format!("Bearer {}", self.access_token))
             .json(body)
             .send()
@@ -147,7 +147,7 @@ impl OutlookCalendarRestApi {
     ) -> anyhow::Result<T> {
         match self
             .client
-            .post(&format!("{}/{}", API_BASE_URL, path))
+            .post(format!("{}/{}", API_BASE_URL, path))
             .header("authorization", format!("Bearer {}", self.access_token))
             .json(body)
             .send()
@@ -173,7 +173,7 @@ impl OutlookCalendarRestApi {
     async fn delete<T: for<'de> Deserialize<'de>>(&self, path: String) -> anyhow::Result<T> {
         match self
             .client
-            .delete(&format!("{}/{}", API_BASE_URL, path))
+            .delete(format!("{}/{}", API_BASE_URL, path))
             .header("authorization", format!("Bearer {}", self.access_token))
             .send()
             .await
@@ -198,7 +198,7 @@ impl OutlookCalendarRestApi {
     async fn get<T: for<'de> Deserialize<'de>>(&self, path: String) -> anyhow::Result<T> {
         match self
             .client
-            .get(&format!("{}/{}", API_BASE_URL, path))
+            .get(format!("{}/{}", API_BASE_URL, path))
             .header("authorization", format!("Bearer {}", self.access_token))
             .send()
             .await

--- a/scheduler/crates/infra/src/system/mod.rs
+++ b/scheduler/crates/infra/src/system/mod.rs
@@ -1,9 +1,10 @@
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 
 // Mocking out time so that it is possible to run tests that depend on time.
 pub trait ISys: Send + Sync {
     /// The current timestamp in millis
     fn get_timestamp_millis(&self) -> i64;
+    fn get_timestamp(&self) -> DateTime<Utc>;
 }
 
 /// System that gets the real time and is used when not testing
@@ -11,5 +12,9 @@ pub struct RealSys {}
 impl ISys for RealSys {
     fn get_timestamp_millis(&self) -> i64 {
         Utc::now().timestamp_millis()
+    }
+
+    fn get_timestamp(&self) -> DateTime<Utc> {
+        Utc::now()
     }
 }

--- a/scheduler/debian.Dockerfile
+++ b/scheduler/debian.Dockerfile
@@ -25,6 +25,9 @@ RUN --mount=type=bind,source=src,target=/app/${APP_NAME}/src \
 
 FROM debian:stable-slim
 
+# Enable backtraces
+ENV RUST_BACKTRACE=1
+
 RUN apt update \
   && apt install -y openssl ca-certificates \
   && apt clean \

--- a/scheduler/src/bin/migrate.rs
+++ b/scheduler/src/bin/migrate.rs
@@ -1,6 +1,6 @@
 use nettu_scheduler_infra::run_migration;
 
-#[actix_web::main]
-async fn main() -> () {
-    run_migration().await.unwrap()
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    run_migration().await
 }

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -5,7 +5,7 @@ use nettu_scheduler_infra::setup_context;
 use telemetry::init_subscriber;
 
 #[tokio::main]
-async fn main() -> std::io::Result<()> {
+async fn main() -> anyhow::Result<()> {
     // Initialize the environment variables for SSL certificates
     openssl_probe::init_ssl_cert_env_vars();
 

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -10,9 +10,9 @@ async fn main() -> anyhow::Result<()> {
     openssl_probe::init_ssl_cert_env_vars();
 
     // Initialize the subscriber for logging & tracing
-    init_subscriber();
+    init_subscriber()?;
 
-    let context = setup_context().await;
+    let context = setup_context().await?;
 
     let app = Application::new(context).await?;
     app.start().await

--- a/scheduler/tests/collective_team_scheduling.rs
+++ b/scheduler/tests/collective_team_scheduling.rs
@@ -1,3 +1,7 @@
+// Allow clippy lints because this is a test helper
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
 mod helpers;
 
 use chrono::{Duration, Utc, Weekday};

--- a/scheduler/tests/group_team_scheduling.rs
+++ b/scheduler/tests/group_team_scheduling.rs
@@ -1,3 +1,7 @@
+// Allow clippy lints because this is a test helper
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
 mod helpers;
 
 use chrono::{Duration, Utc, Weekday};

--- a/scheduler/tests/helpers/setup.rs
+++ b/scheduler/tests/helpers/setup.rs
@@ -1,3 +1,6 @@
+// Allow clippy lints because this is a test helper
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 use nettu_scheduler_api::Application;
 use nettu_scheduler_infra::{setup_context, Config, NettuContext};
 use nettu_scheduler_sdk::NettuSDK;
@@ -10,7 +13,7 @@ pub struct TestApp {
 
 // Launch the application as a background task
 pub async fn spawn_app() -> (TestApp, NettuSDK, String) {
-    let mut ctx = setup_context().await;
+    let mut ctx = setup_context().await.unwrap();
     ctx.config.port = 0; // Random port
 
     let config = ctx.config.clone();

--- a/scheduler/tests/round_robin_scheduling.rs
+++ b/scheduler/tests/round_robin_scheduling.rs
@@ -476,6 +476,7 @@ async fn test_round_robin_availability_scheduling() {
                 .events
                 .find(&event_id)
                 .await
+                .unwrap()
                 .expect("To find event");
             service_event.created = *last_assigned_service_event;
             app.ctx

--- a/scheduler/tests/round_robin_scheduling.rs
+++ b/scheduler/tests/round_robin_scheduling.rs
@@ -1,3 +1,7 @@
+// Allow clippy lints because this is a test helper
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+
 mod helpers;
 
 use chrono::{DateTime, Duration, TimeDelta, Utc, Weekday};


### PR DESCRIPTION
## Changed
- Improve a few things (but a lot of times) regarding error handling
  - Remove quite a few usages of `unwrap()` or `expect()`
    - Make them "deny" by default (lint throws an error, but the lint error can be silenced like eslint by adding a comment)
  - Make all the methods on the repositories to return `anyhow::Result<T>`
    - As all of these methods call to the DB, all these methods can potentially fail, so `Result` reflects that

## Details


### Enums

In Rust, there are a few things to keep in mind when handling "errors" and "lack of values (aka null in other languages)"

Rust has 2 enums
- `Option<T>`, which has 2 values => `Some(T)` or `None`
  - This is used for handling cases where a value is optional (undefined/null)
- `Result<T, E>`, which also has 2 values => `Ok(T)` or `Err(E)`
  - This is used for handling cases where something can fail (e.g. a DB call)


So, for example, we can have the following
```rs
let normalField: String = "normalField".to_string();
let optionalFieldWithValue: Option<String> = Some("optionalFieldWithValue".to_string());
let optionalFieldWithoutValue: Option<String> = None;

let processSucceeded: Result<String, String> = Ok("Test".to_string());
// Note that the error can be any type
let processFailed: Result<String, String> = Err("Test".to_string());
```

### Unwrap and expect

On there 2 enums, there are quite a few functions that can be used. There are 2 main ones that we need to be careful about
- `unwrap()`
- `expect()`

Regarding `unwrap()` and `expect()`, it does the following
```rs
let optionalFieldWithValue: Option<String> = Some("optionalFieldWithValue".to_string());
let optionalFieldWithoutValue: Option<String> = None;

let normalField: String = optionalFieldWithValue.unwrap(); // Same with expect

// However, this will panic, meaning (by default) the app crashes ! (called "panic")
let optionalFieldWithoutValue: Option<String> = None;
let normalField: String = optionalFieldWithoutValue.unwrap();

// `expect` is the same as `unwrap`, just that it allows to provide a custom message
// So this still crashes (panic)
let optionalFieldWithoutValue: Option<String> = None;
let normalField: String = optionalFieldWithoutValue.expect("We didn't have a value !");
```

So, in short, `unwrap()` and `expect()` should be avoided as they make the app to crash.

Regarding these 2 enums, it's worth noting that using `?` allows to automatically stop the execution and return the `Err(E)` or `None` (but not a panic !).

### Anyhow

anyhow is a lib that allows to easily forward errors. In the Rust ecosystems, there are 2 main libs used for handling errors
- [anyhow](https://crates.io/crates/anyhow) for applications
- [thiserror](https://crates.io/crates/thiserror) for libraries 

More details in https://google.github.io/comprehensive-rust/error-handling.html (the whole website is a good resource, it's a tutorial from Google's Android team for learning Rust for their own employees

I'll also add some comments in the code in the PR