### PR TITLE
fix(local dev): make app use hardcoded create account secret

### DIFF
--- a/.github/workflows/js-client-test.yml
+++ b/.github/workflows/js-client-test.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - master
+
+env:
+  RUST_BACKTRACE: 1
+
 jobs:
   test:
     name: test
@@ -57,7 +61,6 @@ jobs:
           cargo install sqlx-cli --no-default-features --features postgres || true
           (cd crates/infra && sqlx migrate run)
 
-          export CREATE_ACCOUNT_SECRET_CODE=opqI5r3e7v1z2h3P
           export RUST_LOG=error,tracing=info
 
           cargo build

--- a/scheduler/clients/javascript/tests/helpers/fixtures.ts
+++ b/scheduler/clients/javascript/tests/helpers/fixtures.ts
@@ -3,7 +3,7 @@ import { readPrivateKey, readPublicKey } from './utils'
 import * as jwt from 'jsonwebtoken'
 
 export const CREATE_ACCOUNT_CODE =
-  process.env.CREATE_ACCOUNT_SECRET_CODE || 'opqI5r3e7v1z2h3P'
+  process.env.CREATE_ACCOUNT_SECRET_CODE || 'create_account_dev_secret'
 
 export const setupAccount = async () => {
   const client = NettuClient()

--- a/scheduler/crates/infra/src/config.rs
+++ b/scheduler/crates/infra/src/config.rs
@@ -24,13 +24,24 @@ impl Config {
         let create_account_secret_code = match std::env::var("CREATE_ACCOUNT_SECRET_CODE") {
             Ok(code) => code,
             Err(_) => {
-                info!("Did not find CREATE_ACCOUNT_SECRET_CODE environment variable. Going to create one.");
-                let code = create_random_secret(16);
-                info!(
-                    "Secret code for creating accounts was generated and set to: {}",
+                // If we are in debug mode we set a default secret code
+                if cfg!(debug_assertions) {
+                    let code = "create_account_dev_secret".to_string();
+                    info!(
+                        "Running in debug mode, using default UNSECURE secret code for creating accounts: {}", 
+                        code
+                    );
                     code
-                );
-                code
+                } else {
+                    // Otherwise we generate a random secret code
+                    info!("Did not find CREATE_ACCOUNT_SECRET_CODE environment variable. Going to create one.");
+                    let code = create_random_secret(16);
+                    info!(
+                        "Secret code for creating accounts was generated and set to: {}",
+                        code
+                    );
+                    code
+                }
             }
         };
         let default_port = "5000";


### PR DESCRIPTION
### Changed
- Make the secret for creating account a hardcoded value in dev
  - This allows to run in 2 terminals `just dev` (launch backend) and `pnpm run test` (launch client lib's tests), and make it work out-of-the-box
  - In prod, it still generates a random secret