### PR TITLE
fix: dependabot paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,11 @@ version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directories:
-      - "/clients/javascript"
+      - "/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "cargo" # See documentation for possible values
     directories:
-      - "/bins/nittei"
-      - "/clients/rust"
-      - "/crates/api"
-      - "/crates/api_structs"
-      - "/crates/domain"
-      - "/crates/infra"
-      - "/crates/utils"
+      - "/"
     schedule:
       interval: "weekly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,6 @@
 
 [workspace]
-members = [
-    "bins/nittei",
-    "crates/api",
-    "crates/api_structs",
-    "crates/domain",
-    "crates/infra",
-    "crates/utils",
-    "clients/rust",
-]
+members = ["bins/*", "crates/*", "clients/rust"]
 resolver = "2"
 
 [workspace.dependencies]


### PR DESCRIPTION
### Changes
- For dependabot, specify only the monorepo root, both for pnpm and cargo