### PR TITLE
ci: debug mark as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,12 @@ jobs:
           sed -i "s/\$VERSION_REPLACED_IN_CI/$VERSION/g" charts/nittei/Chart.yaml
           sed -i "s/\$VERSION_REPLACED_IN_CI/$VERSION/g" charts/nittei/values.yaml
 
+      - name: Debug mark as latest
+        run: |
+          echo "github.event.release: ${{ github.event.release }}"
+          echo "github.event.release.prerelease: ${{ github.event.release.prerelease }}"
+          echo "mark_as_latest: ${{ !github.event.release.prerelease }}"
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:


### PR DESCRIPTION
### Changed
- Just added some logs in the CI for debugging the Helm release, as it seems all releases are marked as `latest` (even prereleases)