### PR TITLE
fix: add biome as monorepo dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,7 @@
   },
   "author": "",
   "license": "MIT",
-  "devDependencies": {}
+  "devDependencies": {
+    "@biomejs/biome": "1.9.3"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 1.9.3
+        version: 1.9.3
 
   clients/javascript:
     dependencies:


### PR DESCRIPTION
### Changed
- Just add `biome` as monorepo "main dev dependencies" so that it's picked up by the VSCode extension