### PR TITLE
fix(ci): release tags pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,7 @@ env:
 
 on:
   push:
-    # Sequence of patterns matched against refs/tags
-    # Unfortunately, regex are not fully supported in YAML files, so we cannot
-    # use the officially recommended regex to verify the semantic versioning tag
-    # https://github.com/semver/semver/blob/master/semver.md#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    # Docs on syntax: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+**"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
     # use the officially recommended regex to verify the semantic versioning tag
     # https://github.com/semver/semver/blob/master/semver.md#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-?[a-zA-Z0-9]*"
+      - "v[0-9]+.[0-9]+.[0-9]+**"
 
 # Taken from https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
 jobs:


### PR DESCRIPTION
### Changed
- [ci] Fix pattern matching on tags (based on https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)
  - To be honest, not sure why, but `v0.0.1` wasn't matched
  - With this one, it seems to work
  - As, either way, the goal is not to be "super precise" (as regular expressions are not properly handled either way), but instead to be "precise enough so that the CI triggers only when we want it to be triggered"
  - With that in mind, only matching on the semantic version and allowing any characters afterwards (`**`) should be enough