### PR TITLE
chore: fix duration comments (minutes => seconds)

### DIFF
--- a/clients/javascript/lib/gen_types/CalendarEventDTO.ts
+++ b/clients/javascript/lib/gen_types/CalendarEventDTO.ts
@@ -46,7 +46,7 @@ export type CalendarEventDTO = {
    */
   startTime: Date
   /**
-   * Duration of the event in minutes
+   * Duration of the event in seconds
    */
   duration: number
   /**

--- a/clients/javascript/lib/gen_types/CreateEventRequestBody.ts
+++ b/clients/javascript/lib/gen_types/CreateEventRequestBody.ts
@@ -50,7 +50,7 @@ export type CreateEventRequestBody = {
    */
   startTime: Date
   /**
-   * Duration of the event in minutes
+   * Duration of the event in seconds
    */
   duration: number
   /**

--- a/clients/javascript/lib/gen_types/UpdateEventRequestBody.ts
+++ b/clients/javascript/lib/gen_types/UpdateEventRequestBody.ts
@@ -47,7 +47,7 @@ export type UpdateEventRequestBody = {
    */
   allDay?: boolean
   /**
-   * Optional duration of the event in minutes
+   * Optional duration of the event in seconds
    */
   duration?: number
   /**

--- a/crates/api_structs/src/event/api.rs
+++ b/crates/api_structs/src/event/api.rs
@@ -89,7 +89,7 @@ pub mod create_event {
         #[ts(type = "Date")]
         pub start_time: DateTime<Utc>,
 
-        /// Duration of the event in minutes
+        /// Duration of the event in seconds
         #[ts(type = "number")]
         pub duration: i64,
 
@@ -337,7 +337,7 @@ pub mod update_event {
         #[ts(optional)]
         pub all_day: Option<bool>,
 
-        /// Optional duration of the event in minutes
+        /// Optional duration of the event in seconds
         #[serde(default)]
         #[ts(optional, type = "number")]
         pub duration: Option<i64>,

--- a/crates/api_structs/src/event/dtos.rs
+++ b/crates/api_structs/src/event/dtos.rs
@@ -43,7 +43,7 @@ pub struct CalendarEventDTO {
     #[ts(type = "Date")]
     pub start_time: DateTime<Utc>,
 
-    /// Duration of the event in minutes
+    /// Duration of the event in seconds
     #[ts(type = "number")]
     pub duration: i64,
 


### PR DESCRIPTION
### Changed
- Just adapted the comments on `CalendarEvent`'s `duration`, it should be `seconds` and not `minutes`