### PR TITLE
fix(calendarEvent): duration should be milli + add endTime + fix update

### DIFF
--- a/clients/javascript/lib/gen_types/CalendarEventDTO.ts
+++ b/clients/javascript/lib/gen_types/CalendarEventDTO.ts
@@ -46,7 +46,11 @@ export type CalendarEventDTO = {
    */
   startTime: Date
   /**
-   * Duration of the event in seconds
+   * Start time of the event (UTC)
+   */
+  endTime: Date
+  /**
+   * Duration of the event in milliseconds
    */
   duration: number
   /**

--- a/clients/javascript/lib/gen_types/CreateEventRequestBody.ts
+++ b/clients/javascript/lib/gen_types/CreateEventRequestBody.ts
@@ -50,7 +50,7 @@ export type CreateEventRequestBody = {
    */
   startTime: Date
   /**
-   * Duration of the event in seconds
+   * Duration of the event in milliseconds
    */
   duration: number
   /**

--- a/clients/javascript/lib/gen_types/UpdateEventRequestBody.ts
+++ b/clients/javascript/lib/gen_types/UpdateEventRequestBody.ts
@@ -47,7 +47,7 @@ export type UpdateEventRequestBody = {
    */
   allDay?: boolean
   /**
-   * Optional duration of the event in seconds
+   * Optional duration of the event in milliseconds
    */
   duration?: number
   /**

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import {
   type INitteiClient,
   type INitteiUserClient,
@@ -169,6 +170,37 @@ describe('CalendarEvent API', () => {
         timezone: 'UTC',
       })
       calendarId = calendarRes.calendar.id
+    })
+
+    it('should be able to create event', async () => {
+      const res = await adminClient.events.create(userId, {
+        calendarId,
+        duration: 1000,
+        startTime: new Date(1000),
+      })
+      expect(res.event).toBeDefined()
+      expect(res.event.calendarId).toBe(calendarId)
+    })
+
+    it('should be able to update event', async () => {
+      const res = await adminClient.events.create(userId, {
+        calendarId,
+        duration: 1000,
+        startTime: new Date(1000),
+      })
+      const eventId = res.event.id
+
+      expect(dayjs(res.event.endTime)).toEqual(dayjs(2000))
+
+      const res2 = await adminClient.events.update(eventId, {
+        title: 'new title',
+        startTime: new Date(2000),
+        duration: 2000,
+      })
+      expect(res2.event.title).toBe('new title')
+      expect(dayjs(res2.event.startTime)).toEqual(dayjs(2000))
+      expect(res2.event.duration).toEqual(2000)
+      expect(dayjs(res2.event.endTime)).toEqual(dayjs(4000))
     })
 
     it('should be able to query on external ID', async () => {

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpRequest, HttpResponse};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use event::subscribers::SyncRemindersOnEventUpdated;
 use nittei_api_structs::update_event::*;
 use nittei_domain::{
@@ -250,6 +250,10 @@ impl UseCase for UpdateEventUseCase {
             // This unwrap is safe as we have checked that recurrence "is_some"
             #[allow(clippy::unwrap_used)]
             e.set_recurrence(e.recurrence.clone().unwrap(), &calendar.settings, true)
+        } else if start_or_duration_change {
+            e.end_time = e.start_time + TimeDelta::milliseconds(e.duration);
+            e.recurrence = None;
+            true
         } else {
             e.recurrence = None;
             true

--- a/crates/api_structs/src/event/api.rs
+++ b/crates/api_structs/src/event/api.rs
@@ -89,7 +89,7 @@ pub mod create_event {
         #[ts(type = "Date")]
         pub start_time: DateTime<Utc>,
 
-        /// Duration of the event in seconds
+        /// Duration of the event in milliseconds
         #[ts(type = "number")]
         pub duration: i64,
 
@@ -337,7 +337,7 @@ pub mod update_event {
         #[ts(optional)]
         pub all_day: Option<bool>,
 
-        /// Optional duration of the event in seconds
+        /// Optional duration of the event in milliseconds
         #[serde(default)]
         #[ts(optional, type = "number")]
         pub duration: Option<i64>,

--- a/crates/api_structs/src/event/dtos.rs
+++ b/crates/api_structs/src/event/dtos.rs
@@ -43,7 +43,11 @@ pub struct CalendarEventDTO {
     #[ts(type = "Date")]
     pub start_time: DateTime<Utc>,
 
-    /// Duration of the event in seconds
+    /// Start time of the event (UTC)
+    #[ts(type = "Date")]
+    pub end_time: DateTime<Utc>,
+
+    /// Duration of the event in milliseconds
     #[ts(type = "number")]
     pub duration: i64,
 
@@ -92,6 +96,7 @@ impl CalendarEventDTO {
             parent_id: event.parent_id,
             external_id: event.external_id,
             start_time: event.start_time,
+            end_time: event.end_time,
             duration: event.duration,
             busy: event.busy,
             updated: event.updated,


### PR DESCRIPTION
### Changes
- [CalendarEvent] `duration` is now in milliseconds
- [CalendarEvent] fix `end_time` not updated when `duration` and/or `start_time` are updated
  - `end_time` cannot be provided when creating/updating a calendar event, but it should be updated when the other 2 are updated
- [CalendarEvent] When returning a CalendarEvent, also include `end_time` so that the consumer doesn't have to compute it