### PR TITLE
fix: convert endTime to date

### DIFF
--- a/clients/javascript/lib/helpers/datesConverters.ts
+++ b/clients/javascript/lib/helpers/datesConverters.ts
@@ -13,6 +13,7 @@ export function convertEventDates(event: CalendarEventDTO): CalendarEventDTO {
   return {
     ...event,
     startTime: new Date(event.startTime),
+    endTime: new Date(event.endTime),
     exdates: event.exdates?.map(date => new Date(date)),
   }
 }


### PR DESCRIPTION
### Changed
- Fix `endTime` not being converted to Date in JS