### PR TITLE
chore: remove instrumentation on check connection

### DIFF
--- a/crates/infra/src/repos/status/postgres.rs
+++ b/crates/infra/src/repos/status/postgres.rs
@@ -1,5 +1,4 @@
 use sqlx::PgPool;
-use tracing::instrument;
 
 use super::IStatusRepo;
 
@@ -17,7 +16,6 @@ impl PostgresStatusRepo {
 
 #[async_trait::async_trait]
 impl IStatusRepo for PostgresStatusRepo {
-    #[instrument]
     async fn check_connection(&self) -> anyhow::Result<()> {
         // Send a simple query to check the connection
         sqlx::query("SELECT 1 AS health")


### PR DESCRIPTION
### Changed
- This function is used by the healthcheck route, which is often called
  - Filling APM storage with this route is not really useful, nor is it useful to know what is happening inside this route (as it does nothing)