### PR TITLE
refactor(CalendarEventDTO): set Option<> as optional in TS

### DIFF
--- a/clients/javascript/lib/gen_types/CalendarEventDTO.ts
+++ b/clients/javascript/lib/gen_types/CalendarEventDTO.ts
@@ -16,15 +16,15 @@ export type CalendarEventDTO = {
   /**
    * Optional title of the event
    */
-  title: string | null
+  title?: string
   /**
    * Optional description of the event
    */
-  description: string | null
+  description?: string
   /**
    * Optional location of the event
    */
-  location: string | null
+  location?: string
   /**
    * Flag to indicate if the event is all day, default is false
    */
@@ -36,11 +36,11 @@ export type CalendarEventDTO = {
   /**
    * Optional parent event ID
    */
-  parentId: string | null
+  parentId?: string
   /**
    * Optional external ID
    */
-  externalId: string | null
+  externalId?: string
   /**
    * Start time of the event (UTC)
    */
@@ -84,7 +84,7 @@ export type CalendarEventDTO = {
   /**
    * Optional group ID
    */
-  groupId: ID | null
+  groupId?: ID
   /**
    * List of reminders
    */

--- a/crates/api_structs/src/event/dtos.rs
+++ b/crates/api_structs/src/event/dtos.rs
@@ -19,12 +19,15 @@ pub struct CalendarEventDTO {
     pub id: ID,
 
     /// Optional title of the event
+    #[ts(optional)]
     pub title: Option<String>,
 
     /// Optional description of the event
+    #[ts(optional)]
     pub description: Option<String>,
 
     /// Optional location of the event
+    #[ts(optional)]
     pub location: Option<String>,
 
     /// Flag to indicate if the event is all day, default is false
@@ -34,9 +37,11 @@ pub struct CalendarEventDTO {
     pub status: CalendarEventStatus,
 
     /// Optional parent event ID
+    #[ts(optional)]
     pub parent_id: Option<String>,
 
     /// Optional external ID
+    #[ts(optional)]
     pub external_id: Option<String>,
 
     /// Start time of the event (UTC)
@@ -77,6 +82,7 @@ pub struct CalendarEventDTO {
     pub user_id: ID,
 
     /// Optional group ID
+    #[ts(optional)]
     pub group_id: Option<ID>,
 
     /// List of reminders


### PR DESCRIPTION
### Changed
- Set `Option<_>` types as optionals in Typescript (`?:`) instead of `null`