### PR TITLE
feat(calendar events): allow to specify predefined created/updated (dates) when creating

### DIFF
--- a/clients/javascript/lib/gen_types/CreateEventRequestBody.ts
+++ b/clients/javascript/lib/gen_types/CreateEventRequestBody.ts
@@ -81,4 +81,14 @@ export type CreateEventRequestBody = {
    * Optional metadata (e.g. {"key": "value"})
    */
   metadata?: JsonValue
+  /**
+   * Optional created date
+   * Defaults to the current date and time
+   */
+  created?: Date
+  /**
+   * Optional updated date
+   * Defaults to the current date and time
+   */
+  updated?: Date
 }

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -182,6 +182,21 @@ describe('CalendarEvent API', () => {
       expect(res.event.calendarId).toBe(calendarId)
     })
 
+    it('should be able to create event with a predefined "created" and "updated"', async () => {
+      const res = await adminClient.events.create(userId, {
+        calendarId,
+        duration: 1000,
+        startTime: new Date(1000),
+        created: new Date(0),
+        updated: new Date(0),
+      })
+      expect(res.event).toBeDefined()
+      expect(res.event.calendarId).toBe(calendarId)
+
+      expect(res.event.created).toEqual(new Date(0))
+      expect(res.event.updated).toEqual(new Date(0))
+    })
+
     it('should be able to update event', async () => {
       const res = await adminClient.events.create(userId, {
         calendarId,

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -193,8 +193,8 @@ describe('CalendarEvent API', () => {
       expect(res.event).toBeDefined()
       expect(res.event.calendarId).toBe(calendarId)
 
-      expect(res.event.created).toEqual(new Date(0))
-      expect(res.event.updated).toEqual(new Date(0))
+      expect(res.event.created).toEqual(new Date(0).getTime())
+      expect(res.event.updated).toEqual(new Date(0).getTime())
     })
 
     it('should be able to update event', async () => {

--- a/clients/rust/src/event.rs
+++ b/clients/rust/src/event.rs
@@ -135,6 +135,8 @@ impl CalendarEventClient {
             // TODO
             group_id: None,
             metadata: input.metadata,
+            created: None,
+            updated: None,
         };
 
         self.base

--- a/crates/api/src/event/create_event.rs
+++ b/crates/api/src/event/create_event.rs
@@ -49,6 +49,8 @@ pub async fn create_event_admin_controller(
         service_id: body.service_id,
         group_id: body.group_id,
         metadata: body.metadata,
+        created: body.created,
+        updated: body.updated,
     };
 
     execute(usecase, &ctx)
@@ -83,6 +85,8 @@ pub async fn create_event_controller(
         service_id: body.service_id,
         group_id: body.group_id,
         metadata: body.metadata,
+        created: body.created,
+        updated: body.updated,
     };
 
     execute_with_policy(usecase, &policy, &ctx)
@@ -110,6 +114,8 @@ pub struct CreateEventUseCase {
     pub service_id: Option<ID>,
     pub group_id: Option<ID>,
     pub metadata: Option<serde_json::Value>,
+    pub created: Option<DateTime<Utc>>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -176,8 +182,6 @@ impl UseCase for CreateEventUseCase {
             busy: self.busy,
             start_time: self.start_time,
             duration: self.duration,
-            created: ctx.sys.get_timestamp_millis(),
-            updated: ctx.sys.get_timestamp_millis(),
             recurrence: None,
             end_time: self.start_time + TimeDelta::milliseconds(self.duration), // default, if recurrence changes, this will be updated
             exdates: Vec::new(),
@@ -188,6 +192,14 @@ impl UseCase for CreateEventUseCase {
             service_id: self.service_id.clone(),
             group_id: self.group_id.clone(),
             metadata: self.metadata.clone(),
+            created: self
+                .created
+                .map(|c| c.timestamp_millis())
+                .unwrap_or(ctx.sys.get_timestamp_millis()),
+            updated: self
+                .updated
+                .map(|c| c.timestamp_millis())
+                .unwrap_or(ctx.sys.get_timestamp_millis()),
         };
 
         if let Some(rrule_opts) = self.recurrence.clone() {

--- a/crates/api_structs/src/event/api.rs
+++ b/crates/api_structs/src/event/api.rs
@@ -126,6 +126,18 @@ pub mod create_event {
         #[serde(default)]
         #[ts(optional)]
         pub metadata: Option<serde_json::Value>,
+
+        /// Optional created date
+        /// Defaults to the current date and time
+        #[serde(default)]
+        #[ts(optional, type = "Date")]
+        pub created: Option<DateTime<Utc>>,
+
+        /// Optional updated date
+        /// Defaults to the current date and time
+        #[serde(default)]
+        #[ts(optional, type = "Date")]
+        pub updated: Option<DateTime<Utc>>,
     }
 
     pub type APIResponse = CalendarEventResponse;


### PR DESCRIPTION
- When creating a calendar event, allow to specify `created` and `updated`, which are timestamps for when the calendar event was created and updated
  - Useful for us as, when double writing, we want to have the same dates on both sides (so that queries return the same)