### PR TITLE
feat(event): allow to override created and updated in "update"

### DIFF
--- a/clients/javascript/lib/gen_types/UpdateEventRequestBody.ts
+++ b/clients/javascript/lib/gen_types/UpdateEventRequestBody.ts
@@ -80,4 +80,12 @@ export type UpdateEventRequestBody = {
    * Optional metadata (e.g. {"key": "value"})
    */
   metadata?: JsonValue
+  /**
+   * Optional created date to use to replace the current one
+   */
+  created?: Date
+  /**
+   * Optional updated date to use to replace the current one
+   */
+  updated?: Date
 }

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -211,11 +211,16 @@ describe('CalendarEvent API', () => {
         title: 'new title',
         startTime: new Date(2000),
         duration: 2000,
+        created: new Date(0),
+        updated: new Date(0),
       })
       expect(res2.event.title).toBe('new title')
       expect(dayjs(res2.event.startTime)).toEqual(dayjs(2000))
       expect(res2.event.duration).toEqual(2000)
       expect(dayjs(res2.event.endTime)).toEqual(dayjs(4000))
+
+      expect(res2.event.created).toEqual(new Date(0).getTime())
+      expect(res2.event.updated).toEqual(new Date(0).getTime())
     })
 
     it('should be able to query on external ID', async () => {

--- a/clients/rust/src/event.rs
+++ b/clients/rust/src/event.rs
@@ -181,6 +181,8 @@ impl CalendarEventClient {
             // TODO
             group_id: None,
             metadata: input.metadata,
+            created: None,
+            updated: None,
         };
         self.base
             .put(body, format!("user/events/{}", event_id), StatusCode::OK)

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -57,6 +57,8 @@ pub async fn update_event_admin_controller(
         group_id: body.group_id,
         exdates: body.exdates,
         metadata: body.metadata,
+        created: body.created,
+        updated: body.updated,
     };
 
     execute(usecase, &ctx)
@@ -93,6 +95,8 @@ pub async fn update_event_controller(
         group_id: body.group_id,
         exdates: body.exdates,
         metadata: body.metadata,
+        created: body.created,
+        updated: body.updated,
     };
 
     execute_with_policy(usecase, &policy, &ctx)
@@ -122,6 +126,8 @@ pub struct UpdateEventUseCase {
     pub group_id: Option<ID>,
     pub exdates: Option<Vec<DateTime<Utc>>>,
     pub metadata: Option<serde_json::Value>,
+    pub created: Option<DateTime<Utc>>,
+    pub updated: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug)]
@@ -178,6 +184,8 @@ impl UseCase for UpdateEventUseCase {
             service_id,
             group_id,
             metadata,
+            created,
+            updated,
         } = self;
 
         let mut e = match ctx.repos.events.find(event_id).await {
@@ -299,7 +307,15 @@ impl UseCase for UpdateEventUseCase {
             e.all_day = *all_day;
         }
 
-        e.updated = ctx.sys.get_timestamp_millis();
+        if let Some(created) = created {
+            e.created = created.timestamp_millis();
+        }
+
+        if let Some(updated) = updated {
+            e.updated = updated.timestamp_millis();
+        } else {
+            e.updated = ctx.sys.get_timestamp_millis();
+        }
 
         ctx.repos
             .events

--- a/crates/api_structs/src/event/api.rs
+++ b/crates/api_structs/src/event/api.rs
@@ -461,6 +461,16 @@ pub mod update_event {
         #[serde(default)]
         #[ts(optional)]
         pub metadata: Option<serde_json::Value>,
+
+        /// Optional created date to use to replace the current one
+        #[serde(default)]
+        #[ts(optional, type = "Date")]
+        pub created: Option<DateTime<Utc>>,
+
+        /// Optional updated date to use to replace the current one
+        #[serde(default)]
+        #[ts(optional, type = "Date")]
+        pub updated: Option<DateTime<Utc>>,
     }
 
     #[derive(Deserialize)]


### PR DESCRIPTION
### Changed
- Allow to specify the new `created` and `updated` when updating calendar events