### PR TITLE
fix(infra): improve performance of `get_by_external_id` (with groups)

### DIFF
--- a/crates/infra/.sqlx/query-7ca1e21500b0ee13496086f3258b98d9993127ede389814e6800822b0a7b7b57.json
+++ b/crates/infra/.sqlx/query-7ca1e21500b0ee13496086f3258b98d9993127ede389814e6800822b0a7b7b57.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT e.*, u.user_uid, account_uid FROM calendar_events AS e\n            INNER JOIN calendars AS c\n                ON c.calendar_uid = e.calendar_uid\n            INNER JOIN users AS u\n                ON u.user_uid = c.user_uid\n            LEFT JOIN events_groups AS g\n                ON g.group_uid = e.group_uid AND g.calendar_uid = e.calendar_uid\n            WHERE u.account_uid = $1\n                AND (e.external_id = $2 OR g.external_id = $2)\n            ",
+  "query": "\n        SELECT e.*, u.user_uid, account_uid \n        FROM calendar_events AS e\n        INNER JOIN calendars AS c\n            ON c.calendar_uid = e.calendar_uid\n        INNER JOIN users AS u\n            ON u.user_uid = c.user_uid\n        LEFT JOIN events_groups AS g\n            ON g.group_uid = e.group_uid AND g.calendar_uid = e.calendar_uid\n        WHERE u.account_uid = $1 AND g.external_id = $2\n        ",
   "describe": {
     "columns": [
       {
@@ -157,5 +157,5 @@
       false
     ]
   },
-  "hash": "e612349310282a71096c6bbad22ca8ed71c178bc92282e84f680d8b089ca8d1d"
+  "hash": "7ca1e21500b0ee13496086f3258b98d9993127ede389814e6800822b0a7b7b57"
 }

--- a/crates/infra/.sqlx/query-dff6107515f942d02e2ca40164678d8ef1897aa84c8dc0a7a3ffca5a8747ef33.json
+++ b/crates/infra/.sqlx/query-dff6107515f942d02e2ca40164678d8ef1897aa84c8dc0a7a3ffca5a8747ef33.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT e.*, u.user_uid, account_uid \n        FROM calendar_events AS e\n        INNER JOIN calendars AS c\n            ON c.calendar_uid = e.calendar_uid\n        INNER JOIN users AS u\n            ON u.user_uid = c.user_uid\n        WHERE u.account_uid = $1 AND e.external_id = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "event_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "calendar_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "parent_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "location",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "all_day",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "start_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "duration",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 10,
+        "name": "end_time",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 11,
+        "name": "busy",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "created",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 13,
+        "name": "updated",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 14,
+        "name": "recurrence",
+        "type_info": "Json"
+      },
+      {
+        "ordinal": 15,
+        "name": "exdates",
+        "type_info": "TimestamptzArray"
+      },
+      {
+        "ordinal": 16,
+        "name": "reminders",
+        "type_info": "Json"
+      },
+      {
+        "ordinal": 17,
+        "name": "service_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 18,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 19,
+        "name": "external_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "group_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 21,
+        "name": "event_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "user_uid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 23,
+        "name": "account_uid",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "dff6107515f942d02e2ca40164678d8ef1897aa84c8dc0a7a3ffca5a8747ef33"
+}

--- a/crates/infra/migrations/20250123000000_add_group_calendar_uid_index.sql
+++ b/crates/infra/migrations/20250123000000_add_group_calendar_uid_index.sql
@@ -1,0 +1,2 @@
+-- Add an index on `calendar_uid` in `events_groups`
+CREATE INDEX IF NOT EXISTS events_groups__calendar_uid_idx ON events_groups (calendar_uid);

--- a/crates/infra/migrations/20250123000000_add_group_calendar_uid_index.sql
+++ b/crates/infra/migrations/20250123000000_add_group_calendar_uid_index.sql
@@ -1,2 +1,0 @@
--- Add an index on `calendar_uid` in `events_groups`
-CREATE INDEX IF NOT EXISTS events_groups__calendar_uid_idx ON events_groups (calendar_uid);

--- a/crates/infra/migrations/20250123000000_add_indexes_for_get_external_id.sql
+++ b/crates/infra/migrations/20250123000000_add_indexes_for_get_external_id.sql
@@ -1,0 +1,8 @@
+-- Add an index on `calendar_uid` in `events_groups`
+CREATE INDEX IF NOT EXISTS events_groups__calendar_uid_idx ON events_groups (calendar_uid);
+
+-- Add an index on `calendar_uid` in `calendar_events`
+CREATE INDEX IF NOT EXISTS calendar_events__calendar_uid_idx ON calendar_events (calendar_uid);
+
+-- Add an index on `account_uid` in `users`
+CREATE INDEX IF NOT EXISTS users__account_uid_idx ON users (account_uid);

--- a/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -1,6 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use chrono::{DateTime, Utc};
+use futures::future;
 use nittei_domain::{CalendarEvent, CalendarEventReminder, RRuleOptions, ID};
 use serde_json::Value;
 use sqlx::{
@@ -50,7 +51,7 @@ impl From<MostRecentCreatedServiceEventsRaw> for MostRecentCreatedServiceEvents 
     }
 }
 
-#[derive(Debug, FromRow, Clone)]
+#[derive(Debug, FromRow, Clone, sqlx::Type)]
 struct EventRaw {
     event_uid: Uuid,
     calendar_uid: Uuid,
@@ -284,33 +285,59 @@ impl IEventRepo for PostgresEventRepo {
         include_groups: bool,
     ) -> anyhow::Result<Vec<CalendarEvent>> {
         if include_groups {
-            sqlx::query_as!(
+            // Define two queries and merge the results
+            let query_calendar_event = sqlx::query_as!(
                 EventRaw,
                 r#"
-            SELECT e.*, u.user_uid, account_uid FROM calendar_events AS e
-            INNER JOIN calendars AS c
-                ON c.calendar_uid = e.calendar_uid
-            INNER JOIN users AS u
-                ON u.user_uid = c.user_uid
-            LEFT JOIN events_groups AS g
-                ON g.group_uid = e.group_uid AND g.calendar_uid = e.calendar_uid
-            WHERE u.account_uid = $1
-                AND (e.external_id = $2 OR g.external_id = $2)
-            "#,
+        SELECT e.*, u.user_uid, account_uid 
+        FROM calendar_events AS e
+        INNER JOIN calendars AS c
+            ON c.calendar_uid = e.calendar_uid
+        INNER JOIN users AS u
+            ON u.user_uid = c.user_uid
+        WHERE u.account_uid = $1 AND e.external_id = $2
+        "#,
                 account_uid.as_ref(),
-                external_id,
+                external_id
+            );
+
+            let query_calendar_events_from_group = sqlx::query_as!(
+                EventRaw,
+                r#"
+        SELECT e.*, u.user_uid, account_uid 
+        FROM calendar_events AS e
+        INNER JOIN calendars AS c
+            ON c.calendar_uid = e.calendar_uid
+        INNER JOIN users AS u
+            ON u.user_uid = c.user_uid
+        LEFT JOIN events_groups AS g
+            ON g.group_uid = e.group_uid AND g.calendar_uid = e.calendar_uid
+        WHERE u.account_uid = $1 AND g.external_id = $2
+        "#,
+                account_uid.as_ref(),
+                external_id
+            );
+
+            // Execute both queries in parallel
+            let (result1, result2) = future::try_join(
+                query_calendar_event.fetch_all(&self.pool),
+                query_calendar_events_from_group.fetch_all(&self.pool),
             )
-            .fetch_all(&self.pool)
             .await
             .inspect_err(|err| {
                 error!(
-                    "Find calendar event with external_id: {:?} failed. DB returned error: {:?}",
+                    "Find calendar event (with group) with external_id: {:?} failed. DB returned error: {:?}",
                     external_id, err
                 );
-            })?
-            .into_iter()
-            .map(|e| e.try_into())
-            .collect()
+            })?;
+
+            // Merge the results
+            let mut all_events = Vec::with_capacity(result1.len() + result2.len());
+            all_events.extend(result1);
+            all_events.extend(result2);
+
+            // Convert the results to CalendarEvent
+            all_events.into_iter().map(|e| e.try_into()).collect()
         } else {
             sqlx::query_as!(
                 EventRaw,

--- a/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -51,7 +51,7 @@ impl From<MostRecentCreatedServiceEventsRaw> for MostRecentCreatedServiceEvents 
     }
 }
 
-#[derive(Debug, FromRow, Clone, sqlx::Type)]
+#[derive(Debug, FromRow, Clone)]
 struct EventRaw {
     event_uid: Uuid,
     calendar_uid: Uuid,

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -1,3 +1,7 @@
+# Usage:
+# docker buildx build -f debian.Dockerfile -t image:tag --build-arg='ARCH=x86_64' --platform linux/amd64 .
+# docker buildx build -f debian.Dockerfile -t image:tag --build-arg='ARCH=aarch64' --platform linux/arm64 .
+
 ARG RUST_VERSION=1.84.0
 ARG APP_NAME=nittei
 


### PR DESCRIPTION
### Changed
- Refactored `get_by_external_id` (with groups) query and split it into 2 queries
  - The use of `OR` is suboptimal
  - Using `UNION ALL` could have worked, but it doesn't work well with sqlx (we lose the query check/type check)
  - So I've split into 2 parallel queries, which shouldn't be too impacting performance-wise
- Fix: add an index on `calendar_uid` in `events_groups`
- Fix: add an index on `calendar_uid` in `calendar_events` (I was surprised that it's not there yet)
- Fix: add an index on `account_uid` in `users` (same, imo should have been there from the start)