### PR TITLE
fix(js client): add default timeout of 5s

### DIFF
--- a/clients/javascript/lib/baseClient.ts
+++ b/clients/javascript/lib/baseClient.ts
@@ -151,6 +151,7 @@ export const createAxiosInstanceFrontend = (
   credentials: ICredentials
 ): AxiosInstance => {
   const config: AxiosRequestConfig = {
+    timeout: 5000, // Default timeout of 5 seconds
     baseURL: args.baseUrl,
     headers: credentials.createAuthHeaders(),
     validateStatus: () => true, // allow all status codes without throwing error
@@ -188,6 +189,7 @@ export const createAxiosInstanceBackend = async (
   credentials: ICredentials
 ): Promise<AxiosInstance> => {
   const config: AxiosRequestConfig = {
+    timeout: 5000, // Default timeout of 5 seconds
     baseURL: args.baseUrl,
     headers: credentials.createAuthHeaders(),
     validateStatus: () => true, // allow all status codes without throwing error

--- a/clients/javascript/lib/baseClient.ts
+++ b/clients/javascript/lib/baseClient.ts
@@ -151,7 +151,7 @@ export const createAxiosInstanceFrontend = (
   credentials: ICredentials
 ): AxiosInstance => {
   const config: AxiosRequestConfig = {
-    timeout: 5000, // Default timeout of 5 seconds
+    timeout: 5_000, // Default timeout of 5 seconds
     baseURL: args.baseUrl,
     headers: credentials.createAuthHeaders(),
     validateStatus: () => true, // allow all status codes without throwing error
@@ -189,7 +189,7 @@ export const createAxiosInstanceBackend = async (
   credentials: ICredentials
 ): Promise<AxiosInstance> => {
   const config: AxiosRequestConfig = {
-    timeout: 5000, // Default timeout of 5 seconds
+    timeout: 5_000, // Default timeout of 5 seconds
     baseURL: args.baseUrl,
     headers: credentials.createAuthHeaders(),
     validateStatus: () => true, // allow all status codes without throwing error


### PR DESCRIPTION
### Changed
- (js client) Add a timeout of 5s on both clients (frontend, backend)
  - Avoids getting stuck indefinitely on a HTTP request