### PR TITLE
refactor(shutdown): avoid returning 503 and wait less

### DIFF
--- a/bins/nittei/src/main.rs
+++ b/bins/nittei/src/main.rs
@@ -30,8 +30,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Listen for SIGINT (Ctrl+C) to shutdown the service
     // This sends a message on the channel to shutdown the server gracefully
-    // By doing so, it makes the app return failed status on the status API endpoint (useful for k8s)
-    // It waits for a configurable amount of seconds (in order for the readiness probe to fail)
+    // It waits for a configurable amount of seconds (in order for the pod to be removed from the k8s service)
     // And then waits for the server to finish processing the current requests before shutting down
     tokio::spawn(async move {
         if let Err(e) = signal::ctrl_c().await {

--- a/crates/api/src/status/mod.rs
+++ b/crates/api/src/status/mod.rs
@@ -2,21 +2,8 @@ use actix_web::{web, HttpResponse};
 use nittei_api_structs::get_service_health::*;
 use nittei_infra::NitteiContext;
 
-use crate::ServerSharedState;
-
 /// Get the status of the service
-async fn status(
-    ctx: web::Data<NitteiContext>,
-    shared_state: web::Data<ServerSharedState>,
-) -> HttpResponse {
-    let is_shutting_down = shared_state.is_shutting_down.lock().await;
-
-    if *is_shutting_down {
-        return HttpResponse::ServiceUnavailable().json(APIResponse {
-            message: "Service is shutting down".into(),
-        });
-    }
-
+async fn status(ctx: web::Data<NitteiContext>) -> HttpResponse {
     match ctx.repos.status.check_connection().await {
         Ok(_) => HttpResponse::Ok().json(APIResponse {
             message: "Ok!\r\n".into(),

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -18,12 +18,12 @@ pub struct AppConfig {
     pub http_port: usize,
 
     /// The sleep time for the HTTP server shutdown (in seconds)
-    /// Default is 25 seconds
+    /// Default is 5 seconds
     /// Env var: NITTEI__SERVER_SHUTDOWN_SLEEP
     pub server_shutdown_sleep: u64,
 
     /// The shutdown timeout for the HTTP server (in seconds)
-    /// Default is 5 seconds
+    /// Default is 10 seconds
     /// Env var: NITTEI__SERVER_SHUTDOWN_TIMEOUT
     pub server_shutdown_timeout: u64,
 
@@ -149,9 +149,9 @@ fn parse_config() -> AppConfig {
         .expect("Failed to set default host")
         .set_default("http_port", "5000")
         .expect("Failed to set default port")
-        .set_default("server_shutdown_sleep", "25")
+        .set_default("server_shutdown_sleep", "5")
         .expect("Failed to set default server_shutdown_sleep")
-        .set_default("server_shutdown_timeout", "5")
+        .set_default("server_shutdown_timeout", "10")
         .expect("Failed to set default server_shutdown_timeout")
         .set_default("skip_db_migrations", false)
         .expect("Failed to set default skip_db_migrations")


### PR DESCRIPTION
### Changed
- Remove the whole "send 503" when shutting down, as after verification, it's an incorrect way to handle the shutdown