### PR TITLE
feat: use jemalloc in all cases

### DIFF
--- a/bins/nittei/Cargo.toml
+++ b/bins/nittei/Cargo.toml
@@ -44,11 +44,8 @@ openssl-probe = "0.1.2"
 chrono = "0.4.19"
 chrono-tz = "0.8.1"
 
-# Use Jemalloc only for musl-64 bits platforms
-# The default MUSL allocator is known to be slower than Jemalloc
-# E.g. https://github.com/BurntSushi/ripgrep/commit/03bf37ff4a29361c47843369f7d3dc5689b8fdac
-[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.tikv-jemallocator]
-version = "0.5"
+# Use the `jemallocator` crate to use jemalloc as the global allocator.
+tikv-jemallocator = "0.5"
 
 
 ##################

--- a/bins/nittei/src/main.rs
+++ b/bins/nittei/src/main.rs
@@ -3,15 +3,10 @@ mod telemetry;
 use nittei_api::Application;
 use nittei_infra::setup_context;
 use telemetry::init_subscriber;
-#[cfg(all(target_env = "musl", target_pointer_width = "64"))]
 use tikv_jemallocator::Jemalloc;
 use tokio::signal;
 use tracing::{error, info};
 
-// Use Jemalloc only for musl-64 bits platforms
-// The default MUSL allocator is known to be slower than Jemalloc
-// E.g. https://github.com/BurntSushi/ripgrep/commit/03bf37ff4a29361c47843369f7d3dc5689b8fdac
-#[cfg(all(target_env = "musl", target_pointer_width = "64"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
### Changed
- Changed default allocator from system allocator to jemalloc for all envs
  - Default is nice, but from what I read, jemalloc is slightly better for long-running apps (e.g. it's the default for https://github.com/cloudflare/foundations)