### PR TITLE
feat(user): return conflict error for external_id on create

### DIFF
--- a/clients/javascript/lib/baseClient.ts
+++ b/clients/javascript/lib/baseClient.ts
@@ -6,6 +6,7 @@ import axios, {
 import type { ICredentials } from './helpers/credentials'
 import {
   BadRequestError,
+  ConflictError,
   NotFoundError,
   UnauthorizedError,
 } from './helpers/errors'
@@ -116,7 +117,9 @@ export abstract class NitteiBaseClient {
    */
   private handleStatusCode(res: AxiosResponse): void {
     if (res.status >= 500) {
-      throw new Error('Internal server error, please try again later')
+      throw new Error(
+        `Internal server error, please try again later (${res.status})`
+      )
     }
 
     if (res.status >= 400) {
@@ -128,6 +131,9 @@ export abstract class NitteiBaseClient {
       }
       if (res.status === 404) {
         throw new NotFoundError(res.data)
+      }
+      if (res.status === 409) {
+        throw new ConflictError(res.data)
       }
       throw new Error(`Request failed with status code ${res.status}`)
     }

--- a/clients/javascript/lib/helpers/errors.ts
+++ b/clients/javascript/lib/helpers/errors.ts
@@ -33,3 +33,16 @@ export class UnauthorizedError extends Error {
     super('Unauthorized')
   }
 }
+
+/**
+ * Error thrown when a request is made to the server and the server responds with a 409 status code
+ */
+export class ConflictError extends Error {
+  /**
+   *
+   * @param apiMessage - error message from the server
+   */
+  constructor(public apiMessage: string) {
+    super('Conflict')
+  }
+}

--- a/clients/javascript/tests/user.spec.ts
+++ b/clients/javascript/tests/user.spec.ts
@@ -5,6 +5,7 @@ import {
   type INitteiUserClient,
   NitteiClient,
 } from '../lib'
+import { ConflictError } from '../lib/helpers/errors'
 import { setupUserClient } from './helpers/fixtures'
 
 describe('User API', () => {
@@ -76,6 +77,25 @@ describe('User API', () => {
     await expect(() =>
       accountClient.user.getByExternalId(res.user.externalId ?? '')
     ).rejects.toThrow()
+  })
+
+  it('should try to create a 4th user, and fail due to same external ID', async () => {
+    const externalId = v4()
+
+    // Create the user
+    const res = await accountClient.user.create({
+      externalId: externalId,
+    })
+
+    // Try to create the same user again
+    await expect(() =>
+      accountClient.user.create({
+        externalId: externalId,
+      })
+    ).rejects.toThrow(ConflictError)
+
+    // Clean up
+    await accountClient.user.remove(res.user.id)
   })
 
   it('should not show any freebusy with no events', async () => {


### PR DESCRIPTION
### Changed
- Return a 409 conflict error when creating a user with an already assigned id/external_id