### PR TITLE
fix(freebusy): sort by start_time

### DIFF
--- a/crates/api/src/user/get_multiple_users_freebusy.rs
+++ b/crates/api/src/user/get_multiple_users_freebusy.rs
@@ -179,6 +179,11 @@ impl GetMultipleFreeBusyUseCase {
             }
         }
 
+        // Sort the events by start time
+        for (_, events) in events_per_user.iter_mut() {
+            events.sort_by(|a, b| a.start_time.cmp(&b.start_time));
+        }
+
         Ok(events_per_user)
     }
 }
@@ -293,16 +298,16 @@ mod test {
             instances[1],
             EventInstance {
                 busy: true,
-                start_time: DateTime::from_timestamp_millis(172800000).unwrap(),
-                end_time: DateTime::from_timestamp_millis(176400000).unwrap(),
+                start_time: DateTime::from_timestamp_millis(100800000).unwrap(),
+                end_time: DateTime::from_timestamp_millis(104400000).unwrap(),
             }
         );
         assert_eq!(
             instances[2],
             EventInstance {
                 busy: true,
-                start_time: DateTime::from_timestamp_millis(100800000).unwrap(),
-                end_time: DateTime::from_timestamp_millis(104400000).unwrap(),
+                start_time: DateTime::from_timestamp_millis(172800000).unwrap(),
+                end_time: DateTime::from_timestamp_millis(176400000).unwrap(),
             }
         );
         assert_eq!(

--- a/crates/api/src/user/get_user_freebusy.rs
+++ b/crates/api/src/user/get_user_freebusy.rs
@@ -159,7 +159,13 @@ impl GetFreeBusyUseCase {
         }
 
         // Expand the events, remove the exceptions and return the expanded events
-        expand_all_events_and_remove_exceptions(&calendars_lookup, &events, timespan)
+        let mut events =
+            expand_all_events_and_remove_exceptions(&calendars_lookup, &events, timespan)?;
+
+        // Sort the events by start_time
+        events.sort_by(|a, b| a.start_time.cmp(&b.start_time));
+
+        Ok(events)
     }
 }
 


### PR DESCRIPTION
### Changed
- In freebusy / multiple freebusy, return a sorted array instead of the random order 