### PR TITLE
fix(recurrence): UNTIL should be UTC

### DIFF
--- a/crates/api/src/event/create_event.rs
+++ b/crates/api/src/event/create_event.rs
@@ -157,7 +157,8 @@ impl From<UseCaseError> for NitteiError {
 }
 
 impl From<anyhow::Error> for UseCaseError {
-    fn from(_: anyhow::Error) -> Self {
+    fn from(error: anyhow::Error) -> Self {
+        tracing::error!("[create_event] Unexpected error: {:?}", error);
         UseCaseError::StorageError
     }
 }

--- a/crates/domain/src/shared/recurrence.rs
+++ b/crates/domain/src/shared/recurrence.rs
@@ -94,9 +94,7 @@ impl RRuleOptions {
         calendar_settings: &CalendarSettings,
     ) -> anyhow::Result<RRuleSet> {
         let timezone = calendar_settings.timezone;
-        let until = self
-            .until
-            .map(|u| u.with_timezone(&rrule::Tz::Tz(timezone)));
+        let until = self.until.map(|u| u.with_timezone(&rrule::Tz::UTC));
         let dtstart = start_time.with_timezone(&rrule::Tz::Tz(timezone));
 
         let count = self.count.map(|c| std::cmp::max(c, 0) as u32);


### PR DESCRIPTION
### Changed
- Fix an issue when checking RRULE (recurrence)
  - `until` is expected to be a datetime with UTC timezone by the rrule library
- Added a few additional error logs in order to ease the debugging in the future