### PR TITLE
fix(recurrence): allow big until values

### DIFF
--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
 import {
   type INitteiClient,
   type INitteiUserClient,
@@ -242,6 +242,37 @@ describe('CalendarEvent API', () => {
           interval: 2,
           until: '2024-12-12T14:59:59Z',
           byweekday: ['Fri'],
+          bymonthday: [],
+        })
+      )
+
+      const resEventUntilFarAway = await adminClient.events.create(userId, {
+        calendarId: calendarTokyoId,
+        startTime: dayjs('2022-03-10T09:30:00.000Z').toDate(),
+        duration: 1800000,
+        eventType: 'gcal',
+        recurrence: {
+          freq: 'weekly',
+          interval: 2,
+          count: undefined,
+          until: '2024-10-16T14:59:59.000Z',
+          bysetpos: undefined,
+          byweekday: ['Thu'],
+          bymonthday: [],
+          bymonth: undefined,
+          byyearday: undefined,
+          byweekno: undefined,
+        },
+      })
+
+      expect(resEventUntilFarAway.event).toBeDefined()
+      expect(resEventUntilFarAway.event.calendarId).toBe(calendarTokyoId)
+      expect(resEventUntilFarAway.event.recurrence).toEqual(
+        expect.objectContaining({
+          freq: 'weekly',
+          interval: 2,
+          until: '2024-10-16T14:59:59Z',
+          byweekday: ['Thu'],
           bymonthday: [],
         })
       )

--- a/crates/api/src/event/create_event.rs
+++ b/crates/api/src/event/create_event.rs
@@ -213,9 +213,18 @@ impl UseCase for CreateEventUseCase {
         };
 
         if let Some(rrule_opts) = self.recurrence.clone() {
-            if !(e.set_recurrence(rrule_opts, &calendar.settings, true)?) {
-                return Err(UseCaseError::InvalidRecurrenceRule);
-            };
+            let result = e.set_recurrence(rrule_opts, &calendar.settings, false);
+            match result {
+                Ok(res) => {
+                    if !res {
+                        return Err(UseCaseError::InvalidRecurrenceRule);
+                    }
+                }
+                Err(err) => {
+                    tracing::error!("[create_event] Error setting recurrence: {:?}", err);
+                    return Err(UseCaseError::InvalidRecurrenceRule);
+                }
+            }
         }
 
         // TODO: maybe have reminders length restriction
@@ -246,7 +255,7 @@ impl PermissionBoundary for CreateEventUseCase {
 
 #[cfg(test)]
 mod test {
-    use chrono::{prelude::*, Utc};
+    use chrono::prelude::*;
     use nittei_domain::{Account, Calendar, User};
     use nittei_infra::setup_context;
 
@@ -356,10 +365,6 @@ mod test {
         let mut invalid_rrules = Vec::new();
         invalid_rrules.push(RRuleOptions {
             count: Some(1000), // too big count
-            ..Default::default()
-        });
-        invalid_rrules.push(RRuleOptions {
-            until: Some(Utc.with_ymd_and_hms(2150, 1, 1, 0, 0, 0).unwrap()), // too big until
             ..Default::default()
         });
         for rrule in invalid_rrules {

--- a/crates/domain/src/event.rs
+++ b/crates/domain/src/event.rs
@@ -154,7 +154,7 @@ impl CalendarEvent {
         calendar_settings: &CalendarSettings,
         update_endtime: bool,
     ) -> anyhow::Result<bool> {
-        let valid_recurrence = recurrence.is_valid(self.start_time);
+        let valid_recurrence = recurrence.is_valid();
         if !valid_recurrence {
             return Ok(false);
         }
@@ -344,10 +344,6 @@ mod test {
         let mut invalid_rrules = Vec::new();
         invalid_rrules.push(RRuleOptions {
             count: Some(1000), // too big count
-            ..Default::default()
-        });
-        invalid_rrules.push(RRuleOptions {
-            until: Some(Utc.with_ymd_and_hms(2150, 1, 1, 0, 0, 0).unwrap()), // too big until
             ..Default::default()
         });
         invalid_rrules.push(RRuleOptions {

--- a/crates/domain/src/shared/recurrence.rs
+++ b/crates/domain/src/shared/recurrence.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, fmt::Display, str::FromStr};
 
-use chrono::{prelude::*, TimeDelta};
+use chrono::prelude::*;
 use rrule::{Frequency, RRule, RRuleSet};
 use serde::{de::Visitor, Deserialize, Serialize};
 use thiserror::Error;
@@ -58,19 +58,12 @@ fn is_none_or_empty<T>(v: &Option<Vec<T>>) -> bool {
 }
 
 impl RRuleOptions {
-    pub fn is_valid(&self, start_time: DateTime<Utc>) -> bool {
+    pub fn is_valid(&self) -> bool {
         if let Some(count) = self.count {
             if !(1..740).contains(&count) {
                 return false;
             }
         }
-        let two_years_in_millis = TimeDelta::milliseconds(1000 * 60 * 60 * 24 * 366 * 2);
-        if let Some(until) = self.until {
-            if until < start_time || until - start_time > two_years_in_millis {
-                return false;
-            }
-        }
-
         if let Some(bysetpos) = &self.bysetpos {
             // Check that bysetpos is used with some other by* rule
             if !bysetpos.is_empty()


### PR DESCRIPTION
### Changed
- Remove the check that limit the duration between `startTime` and `until` to be maximum 2 years
  - I suppose it's to avoid having "too big" events
  - But we have events with a bigger `until`, so we need to be able to handle it 