### PR TITLE
feat(helm): allow to specify deployment strategy

### DIFF
--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- if .Values.strategy }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "nittei.selectorLabels" . | nindent 6 }}

--- a/charts/nittei/values.yaml
+++ b/charts/nittei/values.yaml
@@ -125,3 +125,6 @@ tolerations: []
 affinity: {}
 
 revisionHistoryLimit: 5
+
+# Specify the strategy to the Deployment
+strategy: {}


### PR DESCRIPTION
### Changed
- [helm] Allow to override `strategy` for the deployment (particularly useful for configuring `maxSurge`)