### PR TITLE
fix(rrule): remove count limit

### DIFF
--- a/crates/api/src/event/create_event.rs
+++ b/crates/api/src/event/create_event.rs
@@ -346,34 +346,4 @@ mod test {
             UseCaseError::NotFound(usecase.calendar_id)
         );
     }
-
-    #[actix_web::main]
-    #[test]
-    async fn rejects_event_with_invalid_recurrence() {
-        let TestContext {
-            ctx,
-            calendar,
-            user,
-        } = setup().await;
-
-        let mut invalid_rrules = Vec::new();
-        invalid_rrules.push(RRuleOptions {
-            count: Some(1000), // too big count
-            ..Default::default()
-        });
-        for rrule in invalid_rrules {
-            let mut usecase = CreateEventUseCase {
-                start_time: DateTime::from_timestamp_millis(500).unwrap(),
-                duration: 800,
-                recurrence: Some(rrule),
-                calendar_id: calendar.id.clone(),
-                user: user.clone(),
-                ..Default::default()
-            };
-
-            let res = usecase.execute(&ctx).await;
-
-            assert!(res.is_err());
-        }
-    }
 }

--- a/crates/domain/src/event.rs
+++ b/crates/domain/src/event.rs
@@ -362,10 +362,6 @@ mod test {
         };
         let mut invalid_rrules = Vec::new();
         invalid_rrules.push(RRuleOptions {
-            count: Some(1000), // too big count
-            ..Default::default()
-        });
-        invalid_rrules.push(RRuleOptions {
             // Only bysetpos and no by*
             bysetpos: Some(vec![1]),
             freq: RRuleFrequency::Monthly,

--- a/crates/domain/src/shared/recurrence.rs
+++ b/crates/domain/src/shared/recurrence.rs
@@ -59,11 +59,6 @@ fn is_none_or_empty<T>(v: &Option<Vec<T>>) -> bool {
 
 impl RRuleOptions {
     pub fn is_valid(&self) -> bool {
-        if let Some(count) = self.count {
-            if !(1..740).contains(&count) {
-                return false;
-            }
-        }
         if let Some(bysetpos) = &self.bysetpos {
             // Check that bysetpos is used with some other by* rule
             if !bysetpos.is_empty()


### PR DESCRIPTION
### Changed
- Removed the limit on `COUNT` for `rrule`, as we have some users with count = 999, and as the specifications do not specify a max value for `COUNT`