### PR TITLE
fix(js): expose HTTP client in type

### DIFF
--- a/clients/javascript/lib/index.ts
+++ b/clients/javascript/lib/index.ts
@@ -1,3 +1,4 @@
+import type { AxiosInstance } from 'axios'
 import { NitteiAccountClient } from './accountClient'
 import {
   createAxiosInstanceBackend,
@@ -26,6 +27,8 @@ export interface INitteiUserClient {
   service: NitteiServiceUserClient
   schedule: NitteiScheduleUserClient
   user: NitteiUserUserClient
+
+  readonly axiosClient: AxiosInstance
 }
 
 export interface INitteiClient {
@@ -36,6 +39,8 @@ export interface INitteiClient {
   service: NitteiServiceClient
   schedule: NitteiScheduleClient
   user: _NitteiUserClient
+
+  readonly axiosClient: AxiosInstance
 }
 
 /**


### PR DESCRIPTION
### Changed
- Expose the `axiosClient` in the JS types
  - Right now, it's already assigned to the object, but not visible due to it being missing from the types