### PR TITLE
feat: cache get account by apikey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,7 +657,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -809,6 +820,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,7 +933,7 @@ dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.3.3",
  "syn 1.0.109",
 ]
 
@@ -1009,6 +1038,16 @@ checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1160,6 +1199,19 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
 ]
 
 [[package]]
@@ -1502,7 +1554,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -1718,6 +1770,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1866,28 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "event-listener",
+ "futures-util",
+ "loom",
+ "parking_lot 0.12.3",
+ "portable-atomic",
+ "rustc_version 0.4.1",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.61",
+ "uuid",
 ]
 
 [[package]]
@@ -1913,6 +2000,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "futures",
+ "moka",
  "nittei_domain",
  "nittei_utils",
  "reqwest 0.12.4",
@@ -2241,7 +2329,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2432,6 +2520,12 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -2801,7 +2895,16 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.25",
 ]
 
 [[package]]
@@ -2937,6 +3040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,6 +3092,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "semver-parser"
@@ -3471,6 +3586,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -4255,12 +4376,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4278,7 +4463,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4298,18 +4483,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4320,9 +4505,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4332,9 +4517,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4344,15 +4529,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4362,9 +4547,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4374,9 +4559,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4386,9 +4571,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4398,9 +4583,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/api/src/account/account_search_events.rs
+++ b/crates/api/src/account/account_search_events.rs
@@ -6,7 +6,7 @@ use nittei_infra::{NitteiContext, SearchEventsForAccountParams, SearchEventsPara
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn account_search_events_controller(
     body: actix_web_validator::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let body = body.0;
     let usecase = AccountSearchEventsUseCase {

--- a/crates/api/src/account/add_account_integration.rs
+++ b/crates/api/src/account/add_account_integration.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn add_account_integration_controller(
     body: actix_web_validator::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let body = body.0;
     let usecase = AddAccountIntegrationUseCase {

--- a/crates/api/src/account/delete_account_webhook.rs
+++ b/crates/api/src/account/delete_account_webhook.rs
@@ -5,14 +5,14 @@ use nittei_infra::NitteiContext;
 use super::set_account_webhook::SetAccountWebhookUseCase;
 use crate::{
     error::NitteiError,
-    shared::{auth::protect_account_route, usecase::execute},
+    shared::{auth::protect_admin_route, usecase::execute},
 };
 
 pub async fn delete_account_webhook_controller(
     http_req: HttpRequest,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = SetAccountWebhookUseCase {
         account,

--- a/crates/api/src/account/get_account.rs
+++ b/crates/api/src/account/get_account.rs
@@ -10,6 +10,8 @@ pub async fn get_account_controller(
 ) -> Result<HttpResponse, NitteiError> {
     let account_possibly_stale = protect_admin_route(&http_req, &ctx).await?;
 
+    // Refetch the account, as the protect_admin_route uses a cached method
+    // Meaning that the account could have been deleted in the meantime (or updated)
     let account = ctx
         .repos
         .accounts

--- a/crates/api/src/account/get_account.rs
+++ b/crates/api/src/account/get_account.rs
@@ -2,13 +2,13 @@ use actix_web::{HttpRequest, HttpResponse, web};
 use nittei_api_structs::get_account::APIResponse;
 use nittei_infra::NitteiContext;
 
-use crate::{error::NitteiError, shared::auth::protect_account_route};
+use crate::{error::NitteiError, shared::auth::protect_admin_route};
 
 pub async fn get_account_controller(
     http_req: HttpRequest,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account_possibly_stale = protect_account_route(&http_req, &ctx).await?;
+    let account_possibly_stale = protect_admin_route(&http_req, &ctx).await?;
 
     let account = ctx
         .repos

--- a/crates/api/src/account/remove_account_integration.rs
+++ b/crates/api/src/account/remove_account_integration.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn remove_account_integration_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = RemoveAccountIntegrationUseCase {
         account,

--- a/crates/api/src/account/set_account_pub_key.rs
+++ b/crates/api/src/account/set_account_pub_key.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn set_account_pub_key_controller(
     ctx: web::Data<NitteiContext>,
     body: actix_web_validator::Json<RequestBody>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = SetAccountPubKeyUseCase {
         account,

--- a/crates/api/src/account/set_account_webhook.rs
+++ b/crates/api/src/account/set_account_webhook.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn set_account_webhook_controller(
     ctx: web::Data<NitteiContext>,
     body: actix_web_validator::Json<RequestBody>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = SetAccountWebhookUseCase {
         account,

--- a/crates/api/src/calendar/add_sync_calendar.rs
+++ b/crates/api/src/calendar/add_sync_calendar.rs
@@ -16,7 +16,7 @@ use nittei_infra::{
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_account_route},
+        auth::{Permission, account_can_modify_user, protect_admin_route},
         usecase::{PermissionBoundary, UseCase, execute},
     },
 };
@@ -27,7 +27,7 @@ pub async fn add_sync_calendar_admin_controller(
     body: actix_web_validator::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let user = account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 
     let body = body.0;

--- a/crates/api/src/calendar/create_calendar.rs
+++ b/crates/api/src/calendar/create_calendar.rs
@@ -8,7 +8,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_account_route, protect_route},
+        auth::{Permission, account_can_modify_user, protect_admin_route, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -19,7 +19,7 @@ pub async fn create_calendar_admin_controller(
     body: actix_web_validator::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let user = account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 
     let usecase = CreateCalendarUseCase {

--- a/crates/api/src/calendar/delete_calendar.rs
+++ b/crates/api/src/calendar/delete_calendar.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_calendar, protect_account_route, protect_route},
+        auth::{Permission, account_can_modify_calendar, protect_admin_route, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -16,7 +16,7 @@ pub async fn delete_calendar_admin_controller(
     path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let cal = account_can_modify_calendar(&account, &path.calendar_id, &ctx).await?;
 
     let usecase = DeleteCalendarUseCase {

--- a/crates/api/src/calendar/get_calendar.rs
+++ b/crates/api/src/calendar/get_calendar.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_calendar, protect_account_route, protect_route},
+        auth::{account_can_modify_calendar, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn get_calendar_admin_controller(
     path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let cal = account_can_modify_calendar(&account, &path.calendar_id, &ctx).await?;
 
     let usecase = GetCalendarUseCase {

--- a/crates/api/src/calendar/get_calendar_events.rs
+++ b/crates/api/src/calendar/get_calendar_events.rs
@@ -15,7 +15,7 @@ use tracing::error;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_calendar, protect_account_route, protect_route},
+        auth::{account_can_modify_calendar, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -26,7 +26,7 @@ pub async fn get_calendar_events_admin_controller(
     path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let cal = account_can_modify_calendar(&account, &path.calendar_id, &ctx).await?;
 
     let usecase = GetCalendarEventsUseCase {

--- a/crates/api/src/calendar/get_calendars.rs
+++ b/crates/api/src/calendar/get_calendars.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{protect_account_route, protect_route},
+        auth::{protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -18,7 +18,7 @@ pub async fn get_calendars_admin_controller(
     path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let _account = protect_account_route(&http_req, &ctx).await?;
+    let _account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = GetCalendarsUseCase {
         user_id: path.user_id.clone(),

--- a/crates/api/src/calendar/get_calendars_by_meta.rs
+++ b/crates/api/src/calendar/get_calendars_by_meta.rs
@@ -3,14 +3,14 @@ use nittei_api_structs::get_calendars_by_meta::*;
 use nittei_domain::Metadata;
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_account_route};
+use crate::{error::NitteiError, shared::auth::protect_admin_route};
 
 pub async fn get_calendars_by_meta_controller(
     http_req: HttpRequest,
     query_params: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let query = MetadataFindQuery {
         account_id: account.id,

--- a/crates/api/src/calendar/get_google_calendars.rs
+++ b/crates/api/src/calendar/get_google_calendars.rs
@@ -9,7 +9,7 @@ use nittei_infra::{NitteiContext, google_calendar::GoogleCalendarProvider};
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_user, protect_account_route, protect_route},
+        auth::{account_can_modify_user, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -20,7 +20,7 @@ pub async fn get_google_calendars_admin_controller(
     query: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let user = account_can_modify_user(&account, &path.user_id, &ctx).await?;
 
     let usecase = GetGoogleCalendarsUseCase {

--- a/crates/api/src/calendar/get_outlook_calendars.rs
+++ b/crates/api/src/calendar/get_outlook_calendars.rs
@@ -9,7 +9,7 @@ use nittei_infra::{NitteiContext, outlook_calendar::OutlookCalendarProvider};
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_user, protect_account_route, protect_route},
+        auth::{account_can_modify_user, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -20,7 +20,7 @@ pub async fn get_outlook_calendars_admin_controller(
     query: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let user = account_can_modify_user(&account, &path.user_id, &ctx).await?;
 
     let usecase = GetOutlookCalendarsUseCase {

--- a/crates/api/src/calendar/remove_sync_calendar.rs
+++ b/crates/api/src/calendar/remove_sync_calendar.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_account_route},
+        auth::{Permission, account_can_modify_user, protect_admin_route},
         usecase::{PermissionBoundary, UseCase, execute},
     },
 };
@@ -26,7 +26,7 @@ pub async fn remove_sync_calendar_admin_controller(
     body: web::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     // Check if user exists and can be modified by the account
     account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 

--- a/crates/api/src/calendar/update_calendar.rs
+++ b/crates/api/src/calendar/update_calendar.rs
@@ -12,7 +12,7 @@ use crate::{
             Permission,
             account_can_modify_calendar,
             account_can_modify_user,
-            protect_account_route,
+            protect_admin_route,
             protect_route,
         },
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
@@ -25,7 +25,7 @@ pub async fn update_calendar_admin_controller(
     path: web::Path<PathParams>,
     body: actix_web_validator::Json<RequestBody>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let cal = account_can_modify_calendar(&account, &path.calendar_id, &ctx).await?;
     let user = account_can_modify_user(&account, &cal.user_id, &ctx).await?;
 

--- a/crates/api/src/event/create_event.rs
+++ b/crates/api/src/event/create_event.rs
@@ -16,7 +16,7 @@ use crate::{
     error::NitteiError,
     event::subscribers::CreateSyncedEventsOnEventCreated,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_account_route, protect_route},
+        auth::{Permission, account_can_modify_user, protect_admin_route, protect_route},
         usecase::{PermissionBoundary, Subscriber, UseCase, execute, execute_with_policy},
     },
 };
@@ -27,7 +27,7 @@ pub async fn create_event_admin_controller(
     body: actix_web_validator::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let user = account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 
     let body = body.0;

--- a/crates/api/src/event/delete_event.rs
+++ b/crates/api/src/event/delete_event.rs
@@ -15,7 +15,7 @@ use crate::{
             Permission,
             account_can_modify_event,
             account_can_modify_user,
-            protect_account_route,
+            protect_admin_route,
             protect_route,
         },
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
@@ -27,7 +27,7 @@ pub async fn delete_event_admin_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
     let user = account_can_modify_user(&account, &e.user_id, &ctx).await?;
 

--- a/crates/api/src/event/get_event.rs
+++ b/crates/api/src/event/get_event.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_event, protect_account_route, protect_route},
+        auth::{account_can_modify_event, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn get_event_admin_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
 
     let usecase = GetEventUseCase {

--- a/crates/api/src/event/get_event_by_external_id.rs
+++ b/crates/api/src/event/get_event_by_external_id.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn get_event_by_external_id_admin_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = GetEventByExternalIdUseCase {
         account_id: account.id,

--- a/crates/api/src/event/get_event_instances.rs
+++ b/crates/api/src/event/get_event_instances.rs
@@ -14,7 +14,7 @@ use tracing::error;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_event, protect_account_route, protect_route},
+        auth::{account_can_modify_event, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -25,7 +25,7 @@ pub async fn get_event_instances_admin_controller(
     query_params: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
 
     let usecase = GetEventInstancesUseCase {

--- a/crates/api/src/event/get_events_by_calendars.rs
+++ b/crates/api/src/event/get_events_by_calendars.rs
@@ -14,7 +14,7 @@ use tracing::error;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -25,7 +25,7 @@ pub async fn get_events_by_calendars_controller(
     query: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let calendar_ids = match &query.calendar_ids {
         Some(ids) => ids.clone(),

--- a/crates/api/src/event/get_events_by_meta.rs
+++ b/crates/api/src/event/get_events_by_meta.rs
@@ -3,14 +3,14 @@ use nittei_api_structs::get_events_by_meta::*;
 use nittei_domain::Metadata;
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_account_route};
+use crate::{error::NitteiError, shared::auth::protect_admin_route};
 
 pub async fn get_events_by_meta_controller(
     http_req: HttpRequest,
     query_params: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let query = MetadataFindQuery {
         account_id: account.id,

--- a/crates/api/src/event/search_events.rs
+++ b/crates/api/src/event/search_events.rs
@@ -6,7 +6,7 @@ use nittei_infra::{NitteiContext, SearchEventsForUserParams, SearchEventsParams}
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn search_events_controller(
     body: actix_web_validator::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let body = body.0;
     let usecase = SearchEventsUseCase {

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -20,7 +20,7 @@ use crate::{
             Permission,
             account_can_modify_event,
             account_can_modify_user,
-            protect_account_route,
+            protect_admin_route,
             protect_route,
         },
         usecase::{PermissionBoundary, Subscriber, UseCase, execute, execute_with_policy},
@@ -33,7 +33,7 @@ pub async fn update_event_admin_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
     let user = account_can_modify_user(&account, &e.user_id, &ctx).await?;
 

--- a/crates/api/src/schedule/create_schedule.rs
+++ b/crates/api/src/schedule/create_schedule.rs
@@ -7,7 +7,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_account_route, protect_route},
+        auth::{Permission, account_can_modify_user, protect_admin_route, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -18,7 +18,7 @@ pub async fn create_schedule_admin_controller(
     body_params: web::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let user = account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 
     let usecase = CreateScheduleUseCase {

--- a/crates/api/src/schedule/delete_schedule.rs
+++ b/crates/api/src/schedule/delete_schedule.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_schedule, protect_account_route, protect_route},
+        auth::{Permission, account_can_modify_schedule, protect_admin_route, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -16,7 +16,7 @@ pub async fn delete_schedule_admin_controller(
     path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let schedule = account_can_modify_schedule(&account, &path.schedule_id, &ctx).await?;
 
     let usecase = DeleteScheduleUseCase {

--- a/crates/api/src/schedule/get_schedule.rs
+++ b/crates/api/src/schedule/get_schedule.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_schedule, protect_account_route, protect_route},
+        auth::{account_can_modify_schedule, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn get_schedule_admin_controller(
     path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let schedule = account_can_modify_schedule(&account, &path.schedule_id, &ctx).await?;
 
     let usecase = GetScheduleUseCase {

--- a/crates/api/src/schedule/get_schedules_by_meta.rs
+++ b/crates/api/src/schedule/get_schedules_by_meta.rs
@@ -3,14 +3,14 @@ use nittei_api_structs::get_schedules_by_meta::*;
 use nittei_domain::Metadata;
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_account_route};
+use crate::{error::NitteiError, shared::auth::protect_admin_route};
 
 pub async fn get_schedules_by_meta_controller(
     http_req: HttpRequest,
     query_params: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let query = MetadataFindQuery {
         account_id: account.id,

--- a/crates/api/src/schedule/update_schedule.rs
+++ b/crates/api/src/schedule/update_schedule.rs
@@ -7,7 +7,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_schedule, protect_account_route, protect_route},
+        auth::{Permission, account_can_modify_schedule, protect_admin_route, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -18,7 +18,7 @@ pub async fn update_schedule_admin_controller(
     body: web::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let schedule = account_can_modify_schedule(&account, &path.schedule_id, &ctx).await?;
 
     let body = body.0;

--- a/crates/api/src/service/add_busy_calendar.rs
+++ b/crates/api/src/service/add_busy_calendar.rs
@@ -18,7 +18,7 @@ use nittei_infra::{
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -29,7 +29,7 @@ pub async fn add_busy_calendar_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let body = body.0;
     let usecase = AddBusyCalendarUseCase {

--- a/crates/api/src/service/add_user_to_service.rs
+++ b/crates/api/src/service/add_user_to_service.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -17,7 +17,7 @@ pub async fn add_user_to_service_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = AddUserToServiceUseCase {
         account,

--- a/crates/api/src/service/create_service.rs
+++ b/crates/api/src/service/create_service.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn create_service_controller(
     body: web::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let body = body.0;
     let usecase = CreateServiceUseCase {

--- a/crates/api/src/service/create_service_event_intend.rs
+++ b/crates/api/src/service/create_service_event_intend.rs
@@ -20,7 +20,7 @@ use super::get_service_bookingslots;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -31,7 +31,7 @@ pub async fn create_service_event_intend_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    protect_account_route(&http_req, &ctx).await?;
+    protect_admin_route(&http_req, &ctx).await?;
 
     let body = body.0;
     let usecase = CreateServiceEventIntendUseCase {

--- a/crates/api/src/service/delete_service.rs
+++ b/crates/api/src/service/delete_service.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn delete_service_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = DeleteServiceUseCase {
         account,

--- a/crates/api/src/service/get_service.rs
+++ b/crates/api/src/service/get_service.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn get_service_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = GetServiceUseCase {
         account,

--- a/crates/api/src/service/get_services_by_meta.rs
+++ b/crates/api/src/service/get_services_by_meta.rs
@@ -3,14 +3,14 @@ use nittei_api_structs::get_services_by_meta::*;
 use nittei_domain::Metadata;
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_account_route};
+use crate::{error::NitteiError, shared::auth::protect_admin_route};
 
 pub async fn get_services_by_meta_controller(
     http_req: HttpRequest,
     query_params: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let query = MetadataFindQuery {
         account_id: account.id,

--- a/crates/api/src/service/remove_busy_calendar.rs
+++ b/crates/api/src/service/remove_busy_calendar.rs
@@ -6,7 +6,7 @@ use nittei_infra::{BusyCalendarIdentifier, ExternalBusyCalendarIdentifier, Nitte
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -17,7 +17,7 @@ pub async fn remove_busy_calendar_controller(
     body: web::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let body = body.0;
 

--- a/crates/api/src/service/remove_service_event_intend.rs
+++ b/crates/api/src/service/remove_service_event_intend.rs
@@ -7,7 +7,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -18,7 +18,7 @@ pub async fn remove_service_event_intend_controller(
     mut path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let query = query_params.0;
     let usecase = RemoveServiceEventIntendUseCase {

--- a/crates/api/src/service/remove_user_from_service.rs
+++ b/crates/api/src/service/remove_user_from_service.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn remove_user_from_service_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = RemoveUserFromServiceUseCase {
         account,

--- a/crates/api/src/service/update_service.rs
+++ b/crates/api/src/service/update_service.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -17,7 +17,7 @@ pub async fn update_service_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let body = body.0;
     let usecase = UpdateServiceUseCase {

--- a/crates/api/src/service/update_service_user.rs
+++ b/crates/api/src/service/update_service_user.rs
@@ -11,7 +11,7 @@ use super::add_user_to_service::{
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -22,7 +22,7 @@ pub async fn update_service_user_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = UpdateServiceUserUseCase {
         account,

--- a/crates/api/src/shared/auth/mod.rs
+++ b/crates/api/src/shared/auth/mod.rs
@@ -7,7 +7,7 @@ pub use route_guards::{
     account_can_modify_event,
     account_can_modify_schedule,
     account_can_modify_user,
-    protect_account_route,
+    protect_admin_route,
     protect_public_account_route,
     protect_route,
 };

--- a/crates/api/src/shared/auth/route_guards.rs
+++ b/crates/api/src/shared/auth/route_guards.rs
@@ -143,11 +143,11 @@ pub async fn protect_route(
     }
 }
 
-/// Protects an `Account` admin route, like updating `AccountSettings`
+/// Protects admin routes
 ///
 /// This function will check if the request has a valid `x-api-key` header
 /// and if the token is the one stored in DB for the `Account`
-pub async fn protect_account_route(
+pub async fn protect_admin_route(
     req: &HttpRequest,
     ctx: &NitteiContext,
 ) -> Result<Account, NitteiError> {
@@ -200,7 +200,7 @@ pub async fn protect_public_account_route(
                 })
         }
         // No nittei-account header, then check if this is an admin client
-        None => protect_account_route(http_req, ctx).await,
+        None => protect_admin_route(http_req, ctx).await,
     }
 }
 

--- a/crates/api/src/user/create_user.rs
+++ b/crates/api/src/user/create_user.rs
@@ -7,7 +7,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -17,7 +17,7 @@ pub async fn create_user_controller(
     body: web::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = CreateUserUseCase {
         account_id: account.id,

--- a/crates/api/src/user/delete_user.rs
+++ b/crates/api/src/user/delete_user.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn delete_user_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = DeleteUserUseCase {
         account,

--- a/crates/api/src/user/get_user.rs
+++ b/crates/api/src/user/get_user.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn get_user_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = GetUserUseCase {
         account,

--- a/crates/api/src/user/get_user_by_external_id.rs
+++ b/crates/api/src/user/get_user_by_external_id.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn get_user_by_external_id_controller(
     path_params: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = GetUserByExternalIdUseCase {
         account,

--- a/crates/api/src/user/get_users_by_meta.rs
+++ b/crates/api/src/user/get_users_by_meta.rs
@@ -3,14 +3,14 @@ use nittei_api_structs::get_users_by_meta::*;
 use nittei_domain::Metadata;
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_account_route};
+use crate::{error::NitteiError, shared::auth::protect_admin_route};
 
 pub async fn get_users_by_meta_controller(
     http_req: HttpRequest,
     query_params: web::Query<QueryParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let query = MetadataFindQuery {
         account_id: account.id,

--- a/crates/api/src/user/oauth_integration.rs
+++ b/crates/api/src/user/oauth_integration.rs
@@ -7,7 +7,7 @@ use nittei_infra::{CodeTokenRequest, NitteiContext, ProviderOAuth};
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_user, protect_account_route, protect_route},
+        auth::{account_can_modify_user, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -18,7 +18,7 @@ pub async fn oauth_integration_admin_controller(
     body: actix_web_validator::Json<RequestBody>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let user = account_can_modify_user(&account, &path.user_id, &ctx).await?;
 
     let usecase = OAuthIntegrationUseCase {

--- a/crates/api/src/user/remove_integration.rs
+++ b/crates/api/src/user/remove_integration.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_user, protect_account_route, protect_route},
+        auth::{account_can_modify_user, protect_admin_route, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -16,7 +16,7 @@ pub async fn remove_integration_admin_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
     let user = account_can_modify_user(&account, &path.user_id, &ctx).await?;
 
     let usecase = OAuthIntegrationUseCase {

--- a/crates/api/src/user/update_user.rs
+++ b/crates/api/src/user/update_user.rs
@@ -6,7 +6,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::protect_account_route,
+        auth::protect_admin_route,
         usecase::{UseCase, execute},
     },
 };
@@ -17,7 +17,7 @@ pub async fn update_user_controller(
     mut path: web::Path<PathParams>,
     ctx: web::Data<NitteiContext>,
 ) -> Result<HttpResponse, NitteiError> {
-    let account = protect_account_route(&http_req, &ctx).await?;
+    let account = protect_admin_route(&http_req, &ctx).await?;
 
     let usecase = UpdateUserUseCase {
         account_id: account.id,

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -34,3 +34,4 @@ sqlx = { version = "0.8.3", features = [
   "chrono",
 ] }
 url = { version = "2.5.2" }
+moka = { version = "0.12.10", features = ["future"] }

--- a/crates/infra/src/repos/account/postgres.rs
+++ b/crates/infra/src/repos/account/postgres.rs
@@ -193,7 +193,7 @@ impl IAccountRepo for PostgresAccountRepo {
             return Ok(Some(account));
         }
 
-        let result: Option<Account> = sqlx::query_as!(
+        let optional_account: Option<Account> = sqlx::query_as!(
             AccountRaw,
             "
             SELECT * FROM accounts
@@ -212,12 +212,12 @@ impl IAccountRepo for PostgresAccountRepo {
         .map(|res| res.try_into())
         .transpose()?;
 
-        if let Some(ref account) = result {
+        if let Some(ref account) = optional_account {
             self.cache
                 .insert(api_key.to_string(), account.clone())
                 .await;
         }
 
-        Ok(result)
+        Ok(optional_account)
     }
 }

--- a/crates/infra/src/services/outlook_calendar/calendar_api.rs
+++ b/crates/infra/src/services/outlook_calendar/calendar_api.rs
@@ -284,8 +284,6 @@ impl OutlookCalendarRestApi {
         let calendar_views = join_all(cal_futures)
             .await
             .into_iter()
-            // Keep the error in the stream, propagate it instead of discarding with `filter_map`
-            .map(|res| res.map_err(anyhow::Error::from))
             // Collect the result and propagate the first encountered error
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()


### PR DESCRIPTION
### Changed
- Add a cache of 5min when fetching the account via the API key (mostly for the [admin route guard](https://github.com/meetsmore/nittei/blob/4ecfd3a5cb734f680dc6ed99c58518e7cf4779b5/crates/api/src/shared/auth/route_guards.rs#L172))
- Renamed admin route guard to make it more explicit


### Notes
- The cache isn't shared. So, if another instance deletes the account, the cache won't be cleared on the current instance
  - This is fine imo:
    -  In the use case of a multi-tenant calendar service (not our use-case), the api calling this/the frontend shouldn't send anymore API calls + the data is deleted, so it would fail with 404 errors on other resources (users/calendars/events)
    - In our use case, we never delete accounts
  - If we need it, we can still change to a shared Redis cache at some point