### PR TITLE
fix(search): wrong table used

### DIFF
--- a/clients/javascript/tests/account.spec.ts
+++ b/clients/javascript/tests/account.spec.ts
@@ -220,5 +220,24 @@ describe('Account API', () => {
         }),
       ])
     })
+
+    it('should be able to search by userId and status', async () => {
+      const res = await adminClient.account.searchEventsInAccount({
+        filter: {
+          userId: {
+            eq: userId,
+          },
+          status: {
+            eq: 'confirmed',
+          },
+        },
+      })
+      expect(res.events.length).toBe(1)
+      expect(res.events).toEqual([
+        expect.objectContaining({
+          id: eventId2,
+        }),
+      ])
+    })
   })
 })

--- a/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -681,7 +681,12 @@ impl IEventRepo for PostgresEventRepo {
 
         query.push_bind::<Uuid>(params.account_id.into());
 
-        apply_id_query(&mut query, "user_uid", &params.search_events_params.user_id);
+        apply_id_query(
+            &mut query,
+            "u",
+            "user_uid",
+            &params.search_events_params.user_id,
+        );
 
         apply_string_query(
             &mut query,

--- a/crates/infra/src/repos/shared/query_structs.rs
+++ b/crates/infra/src/repos/shared/query_structs.rs
@@ -20,7 +20,9 @@ pub struct MetadataFindQuery {
 ///
 /// This can only be used for fields that are UUIDs
 ///
-/// This effectively mutates the query_builder !
+/// Note that the table_name needs to be specified as well as the field_name
+///
+/// This mutates the query_builder !
 pub fn apply_id_query(
     query_builder: &mut sqlx::QueryBuilder<'_, Postgres>,
     table_name: &str,


### PR DESCRIPTION
### Changed
- Fix wrong table being used when searching on `user_uid`