### PR TITLE
feat(search): add externalId, default limit + checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "actix-utils",
  "futures-core",
  "futures-util",
- "mio",
+ "mio 1.0.3",
  "socket2",
  "tokio",
  "tracing",
@@ -1372,6 +1372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2018,17 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -2270,6 +2287,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3976,20 +4003,21 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 0.8.11",
+ "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4004,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/clients/javascript/lib/gen_types/AccountSearchEventsRequestBody.ts
+++ b/clients/javascript/lib/gen_types/AccountSearchEventsRequestBody.ts
@@ -16,6 +16,7 @@ export type AccountSearchEventsRequestBody = {
   sort?: CalendarEventSort
   /**
    * Optional limit to use when searching events (u16)
+   * Defaults to 200
    */
   limit?: number
 }

--- a/clients/javascript/lib/gen_types/AccountSearchEventsRequestBodyFilter.ts
+++ b/clients/javascript/lib/gen_types/AccountSearchEventsRequestBodyFilter.ts
@@ -13,7 +13,11 @@ export type AccountSearchEventsRequestBodyFilter = {
    */
   userId?: IDQuery
   /**
-   * Optional query on parent ID (which is a string as it's an ID from an external system)
+   * Optional query on external ID (which is a string as it's an ID from an external system)
+   */
+  externalId?: StringQuery
+  /**
+   * Optional query on external parent ID (which is a string as it's an ID from an external system)
    */
   externalParentId?: StringQuery
   /**

--- a/clients/javascript/lib/gen_types/SearchEventsRequestBody.ts
+++ b/clients/javascript/lib/gen_types/SearchEventsRequestBody.ts
@@ -16,6 +16,7 @@ export type SearchEventsRequestBody = {
   sort?: CalendarEventSort
   /**
    * Optional limit to use when searching events (u16)
+   * Default is 200
    */
   limit?: number
 }

--- a/clients/javascript/lib/gen_types/SearchEventsRequestBodyFilter.ts
+++ b/clients/javascript/lib/gen_types/SearchEventsRequestBodyFilter.ts
@@ -19,7 +19,11 @@ export type SearchEventsRequestBodyFilter = {
    */
   calendarIds?: Array<ID>
   /**
-   * Optional query on parent ID (which is a string as it's an ID from an external system)
+   * Optional query on external ID (which is a string as it's an ID from an external system)
+   */
+  externalId?: StringQuery
+  /**
+   * Optional query on external parent ID (which is a string as it's an ID from an external system)
    */
   externalParentId?: StringQuery
   /**

--- a/clients/javascript/tests/account.spec.ts
+++ b/clients/javascript/tests/account.spec.ts
@@ -92,6 +92,9 @@ describe('Account API', () => {
     let metadataEventId1: string
     let eventId2: string
     let recurringEventId: string
+
+    const externalId = 'externalId'
+    const externalId2 = 'externalId2'
     beforeAll(async () => {
       const data = await setupAccount()
       adminClient = data.client
@@ -112,6 +115,7 @@ describe('Account API', () => {
         calendarId,
         duration: 1000,
         startTime: new Date(1000),
+        externalId: externalId,
       })
 
       eventId1 = eventRes1.event.id
@@ -120,6 +124,7 @@ describe('Account API', () => {
         calendarId,
         duration: 1000,
         startTime: new Date(1100),
+        externalId: externalId2,
         metadata: {
           string: 'string',
           number: 1,
@@ -291,6 +296,28 @@ describe('Account API', () => {
           expect.objectContaining({
             id: eventId2,
           }),
+          expect.objectContaining({
+            id: eventId1,
+          }),
+          expect.objectContaining({
+            id: metadataEventId1,
+          }),
+        ])
+      )
+    })
+
+    it('should be able to search by externalId', async () => {
+      const res = await adminClient.account.searchEventsInAccount({
+        filter: {
+          externalId: {
+            in: [externalId, externalId2],
+          },
+        },
+      })
+
+      expect(res.events.length).toBe(2)
+      expect(res.events).toEqual(
+        expect.arrayContaining([
           expect.objectContaining({
             id: eventId1,
           }),

--- a/crates/api/src/event/search_events.rs
+++ b/crates/api/src/event/search_events.rs
@@ -23,6 +23,7 @@ pub async fn search_events_controller(
         account_id: account.id,
         user_id: body.filter.user_id,
         calendar_ids: body.filter.calendar_ids,
+        external_id: body.filter.external_id,
         external_parent_id: body.filter.external_parent_id,
         start_time: body.filter.start_time,
         end_time: body.filter.end_time,
@@ -32,7 +33,7 @@ pub async fn search_events_controller(
         is_recurring: body.filter.is_recurring,
         metadata: body.filter.metadata,
         sort: body.sort,
-        limit: body.limit,
+        limit: body.limit.or(Some(200)), // Default limit to 200
     };
 
     execute(usecase, &ctx)
@@ -53,7 +54,10 @@ pub struct SearchEventsUseCase {
     /// If not provided, all calendars will be used
     pub calendar_ids: Option<Vec<ID>>,
 
-    /// Optional query on parent ID (which is a string as it's an ID from an external system)
+    /// Optional query on ID (which is a string as it's an ID from an external system)
+    pub external_id: Option<StringQuery>,
+
+    /// Optional query on external parent ID (which is a string as it's an ID from an external system)
     pub external_parent_id: Option<StringQuery>,
 
     /// Optional query on start time - "lower than or equal", or "great than or equal" (UTC)
@@ -159,6 +163,7 @@ impl UseCase for SearchEventsUseCase {
                 search_events_params: SearchEventsParams {
                     // Force user_id to be the same as the one in the search
                     user_id: Some(IDQuery::Eq(self.user_id.clone())),
+                    external_id: self.external_id.take(),
                     external_parent_id: self.external_parent_id.take(),
                     start_time: self.start_time.take(),
                     end_time: self.end_time.take(),

--- a/crates/api_structs/Cargo.toml
+++ b/crates/api_structs/Cargo.toml
@@ -21,6 +21,7 @@ ts-rs = { version = "10.1.0", features = [
   "uuid-impl",
   "chrono-impl",
   "serde-json-impl",
+  "no-serde-warnings",
 ] }
 
 [dev-dependencies]

--- a/crates/api_structs/src/account/api.rs
+++ b/crates/api_structs/src/account/api.rs
@@ -157,8 +157,12 @@ pub mod account_search_events {
 
     /// Request body for searching events for a whole account (across all users)
     #[derive(Deserialize, Serialize, Validate, TS)]
-    #[serde(rename_all = "camelCase")]
-    #[ts(export, rename = "AccountSearchEventsRequestBody")]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    #[ts(
+        export,
+        rename = "AccountSearchEventsRequestBody",
+        rename_all = "camelCase"
+    )]
     pub struct RequestBody {
         /// Filter to use for searching events
         pub filter: RequestBodyFilter,
@@ -168,20 +172,29 @@ pub mod account_search_events {
         pub sort: Option<CalendarEventSort>,
 
         /// Optional limit to use when searching events (u16)
+        /// Defaults to 200
         #[ts(optional)]
         pub limit: Option<u16>,
     }
 
     /// Request body for searching events for a whole account (across all users)
     #[derive(Deserialize, Serialize, Validate, TS)]
-    #[serde(rename_all = "camelCase")]
-    #[ts(export, rename = "AccountSearchEventsRequestBodyFilter")]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    #[ts(
+        export,
+        rename = "AccountSearchEventsRequestBodyFilter",
+        rename_all = "camelCase"
+    )]
     pub struct RequestBodyFilter {
         /// Optional query on user ID, or list of user IDs
         #[ts(optional)]
         pub user_id: Option<IDQuery>,
 
-        /// Optional query on parent ID (which is a string as it's an ID from an external system)
+        /// Optional query on external ID (which is a string as it's an ID from an external system)
+        #[ts(optional)]
+        pub external_id: Option<StringQuery>,
+
+        /// Optional query on external parent ID (which is a string as it's an ID from an external system)
         #[ts(optional)]
         pub external_parent_id: Option<StringQuery>,
 

--- a/crates/api_structs/src/event/api.rs
+++ b/crates/api_structs/src/event/api.rs
@@ -331,7 +331,7 @@ pub mod search_events {
 
     /// Request body for searching events for one user
     #[derive(Deserialize, Serialize, Validate, TS)]
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
     #[ts(export, rename = "SearchEventsRequestBody")]
     pub struct RequestBody {
         /// Filter to use for searching events
@@ -342,6 +342,7 @@ pub mod search_events {
         pub sort: Option<CalendarEventSort>,
 
         /// Optional limit to use when searching events (u16)
+        /// Default is 200
         #[ts(optional)]
         pub limit: Option<u16>,
     }
@@ -349,8 +350,12 @@ pub mod search_events {
     /// Part of the Request body for searching events for a user
     /// This is the filter
     #[derive(Deserialize, Serialize, Validate, TS)]
-    #[serde(rename_all = "camelCase")]
-    #[ts(export, rename = "SearchEventsRequestBodyFilter")]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    #[ts(
+        export,
+        rename = "SearchEventsRequestBodyFilter",
+        rename_all = "camelCase"
+    )]
     pub struct RequestBodyFilter {
         /// User ID
         pub user_id: ID,
@@ -361,7 +366,11 @@ pub mod search_events {
         #[ts(optional)]
         pub calendar_ids: Option<Vec<ID>>,
 
-        /// Optional query on parent ID (which is a string as it's an ID from an external system)
+        /// Optional query on external ID (which is a string as it's an ID from an external system)
+        #[ts(optional)]
+        pub external_id: Option<StringQuery>,
+
+        /// Optional query on external parent ID (which is a string as it's an ID from an external system)
         #[ts(optional)]
         pub external_parent_id: Option<StringQuery>,
 

--- a/crates/domain/src/shared/datetime_query.rs
+++ b/crates/domain/src/shared/datetime_query.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 #[derive(Deserialize, Serialize, TS, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-#[ts(export, rename = "DateTimeQueryRange")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export, rename = "DateTimeQueryRange", rename_all = "camelCase")]
 pub struct DateTimeQueryRange {
     /// "greater than or equal" query (UTC)
     #[ts(type = "Date", optional)]
@@ -27,8 +27,8 @@ pub struct DateTimeQueryRange {
 
 /// Query parameters for searching on a date time
 #[derive(Deserialize, Serialize, TS, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-#[ts(export, rename = "DateTimeQuery")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export, rename = "DateTimeQuery", rename_all = "camelCase")]
 pub enum DateTimeQuery {
     /// "equal" query (UTC)
     #[ts(type = "Date")]

--- a/crates/domain/src/shared/id_query.rs
+++ b/crates/domain/src/shared/id_query.rs
@@ -5,8 +5,8 @@ use crate::ID;
 
 /// Query parameters for searching on an ID (or list of IDs)
 #[derive(Deserialize, Serialize, TS, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-#[ts(export, rename = "IDQuery")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export, rename = "IDQuery", rename_all = "camelCase")]
 pub enum IDQuery {
     /// ID (equality test)
     Eq(ID),

--- a/crates/domain/src/shared/string_query.rs
+++ b/crates/domain/src/shared/string_query.rs
@@ -3,8 +3,8 @@ use ts_rs::TS;
 
 /// Query parameters for searching on a string
 #[derive(Deserialize, Serialize, TS, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-#[ts(export, rename = "StringQuery")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[ts(export, rename = "StringQuery", rename_all = "camelCase")]
 pub enum StringQuery {
     /// Optional String (equality test)
     Eq(String),
@@ -19,6 +19,5 @@ pub enum StringQuery {
 
     /// Optional list of strings (equality test)
     /// If "eq" is provided, this field is ignored
-    /// (use r# in the field name as "in" is a reserved keyword)
     In(Vec<String>),
 }

--- a/crates/infra/src/repos/event/calendar_event/mod.rs
+++ b/crates/infra/src/repos/event/calendar_event/mod.rs
@@ -40,6 +40,7 @@ pub struct SearchEventsForAccountParams {
 #[derive(Debug, Clone)]
 pub struct SearchEventsParams {
     pub user_id: Option<IDQuery>,
+    pub external_id: Option<StringQuery>,
     pub external_parent_id: Option<StringQuery>,
     pub start_time: Option<DateTimeQuery>,
     pub end_time: Option<DateTimeQuery>,

--- a/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -588,6 +588,12 @@ impl IEventRepo for PostgresEventRepo {
 
         apply_string_query(
             &mut query,
+            "external_id",
+            &params.search_events_params.external_id,
+        );
+
+        apply_string_query(
+            &mut query,
             "external_parent_id",
             &params.search_events_params.external_parent_id,
         );
@@ -693,6 +699,12 @@ impl IEventRepo for PostgresEventRepo {
             "u",
             "user_uid",
             &params.search_events_params.user_id,
+        );
+
+        apply_string_query(
+            &mut query,
+            "external_id",
+            &params.search_events_params.external_id,
         );
 
         apply_string_query(


### PR DESCRIPTION
### Changed
- Make "search events in account" safer
  - Default limit to 200 events
  - Do not allow unknown keys (e.g. typo)
  - Do not allow empty body
- Add `externalId` as a field that can be queried