### PR TITLE
fix(event): end time usages

### DIFF
--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -198,6 +198,23 @@ describe('CalendarEvent API', () => {
       expect(res.event.eventType).toBe('job')
     })
 
+    it('should be able to create event', async () => {
+      const res = await adminClient.events.create(userId, {
+        calendarId,
+        startTime: new Date('2024-06-08T13:00:00.000Z'),
+        duration: 21599999,
+        eventType: 'block',
+        recurrence: {
+          freq: 'weekly',
+          interval: 1,
+        },
+      })
+      expect(res.event).toBeDefined()
+      expect(res.event.calendarId).toBe(calendarId)
+      expect(res.event.eventType).toBe('block')
+      expect(res.event.endTime.toISOString()).toBe('2024-06-08T18:59:59.999Z')
+    })
+
     it('should be able to create event with recurring schedule', async () => {
       const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
       const res = await adminClient.events.create(userId, {

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -198,7 +198,7 @@ describe('CalendarEvent API', () => {
       expect(res.event.eventType).toBe('job')
     })
 
-    it('should be able to create event', async () => {
+    it('should be able to create a recurring block event', async () => {
       const res = await adminClient.events.create(userId, {
         calendarId,
         startTime: new Date('2024-06-08T13:00:00.000Z'),

--- a/crates/api/src/event/create_event.rs
+++ b/crates/api/src/event/create_event.rs
@@ -194,7 +194,7 @@ impl UseCase for CreateEventUseCase {
             start_time: self.start_time,
             duration: self.duration,
             recurrence: None,
-            end_time: self.start_time + TimeDelta::milliseconds(self.duration), // default, if recurrence changes, this will be updated
+            end_time: self.start_time + TimeDelta::milliseconds(self.duration),
             exdates: self.exdates.clone(),
             recurring_event_id: self.recurring_event_id.take(),
             original_start_time: self.original_start_time,
@@ -210,12 +210,10 @@ impl UseCase for CreateEventUseCase {
 
         // If we have recurrence, check if it's valid and set it
         if let Some(rrule_opts) = self.recurrence.clone() {
-            let res = e
-                .set_recurrence(rrule_opts, &calendar.settings, false)
-                .map_err(|e| {
-                    tracing::error!("[create_event] Error setting recurrence: {:?}", e);
-                    UseCaseError::InvalidRecurrenceRule
-                })?;
+            let res = e.set_recurrence(rrule_opts).map_err(|e| {
+                tracing::error!("[create_event] Error setting recurrence: {:?}", e);
+                UseCaseError::InvalidRecurrenceRule
+            })?;
             if !res {
                 return Err(UseCaseError::InvalidRecurrenceRule);
             }

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -230,20 +230,6 @@ impl UseCase for UpdateEventUseCase {
             e.reminders.clone_from(reminders);
         }
 
-        let calendar = match ctx.repos.calendars.find(&e.calendar_id).await {
-            Ok(Some(cal)) => cal,
-            Ok(None) => {
-                return Err(UseCaseError::NotFound(
-                    "Calendar".into(),
-                    e.calendar_id.clone(),
-                ));
-            }
-            Err(e) => {
-                tracing::error!("[update_event] Failed to get one calendar {:?}", e);
-                return Err(UseCaseError::StorageError);
-            }
-        };
-
         let mut start_or_duration_change = false;
 
         if let Some(start_time) = start_time {
@@ -259,29 +245,33 @@ impl UseCase for UpdateEventUseCase {
                 start_or_duration_change = true;
             }
         }
+
+        if start_or_duration_change {
+            e.end_time = e.start_time + TimeDelta::milliseconds(e.duration);
+        }
+
         if let Some(busy) = busy {
             e.busy = *busy;
         }
 
+        // Handle the new recurrence
         let valid_recurrence = if let Some(rrule_opts) = recurrence.clone() {
             // ? should exdates be deleted when rrules are updated
-            e.set_recurrence(rrule_opts, &calendar.settings, true)
-                .map_err(|e| {
-                    tracing::error!("[update_event] Failed to set recurrence {:?}", e);
-                    UseCaseError::InvalidRecurrenceRule
-                })?
+            e.set_recurrence(rrule_opts).map_err(|e| {
+                tracing::error!("[update_event] Failed to set recurrence {:?}", e);
+                UseCaseError::InvalidRecurrenceRule
+            })?
+
+        // Otherwise, we we don't have a new recurrence, but we have an existing one
+        // And the start time or duration has changed, we need to update the recurrence
         } else if start_or_duration_change && e.recurrence.is_some() {
             // This unwrap is safe as we have checked that recurrence "is_some"
             #[allow(clippy::unwrap_used)]
-            e.set_recurrence(e.recurrence.clone().unwrap(), &calendar.settings, true)
+            e.set_recurrence(e.recurrence.clone().unwrap())
                 .map_err(|e| {
                     tracing::error!("[update_event] Failed to set recurrence {:?}", e);
                     UseCaseError::InvalidRecurrenceRule
                 })?
-        } else if start_or_duration_change {
-            e.end_time = e.start_time + TimeDelta::milliseconds(e.duration);
-            e.recurrence = None;
-            true
         } else {
             e.recurrence = None;
             true

--- a/crates/api/src/service/get_service_bookingslots.rs
+++ b/crates/api/src/service/get_service_bookingslots.rs
@@ -626,7 +626,7 @@ mod test {
             ..Default::default()
         };
         let recurrence = RRuleOptions::default();
-        match availability_event3.set_recurrence(recurrence, &calendar_user_2.settings, true) {
+        match availability_event3.set_recurrence(recurrence) {
             Ok(_) => {}
             Err(e) => panic!("Error setting recurrence: {:?}", e),
         };

--- a/crates/api/src/user/get_multiple_users_freebusy.rs
+++ b/crates/api/src/user/get_multiple_users_freebusy.rs
@@ -219,7 +219,7 @@ mod test {
             count: Some(100),
             ..Default::default()
         };
-        match e1.set_recurrence(e1rr, &calendar.settings, true) {
+        match e1.set_recurrence(e1rr) {
             Ok(_) => {}
             Err(e) => {
                 panic!("{:?}", e);
@@ -240,7 +240,7 @@ mod test {
             count: Some(100),
             ..Default::default()
         };
-        match e2.set_recurrence(e2rr, &calendar.settings, true) {
+        match e2.set_recurrence(e2rr) {
             Ok(_) => {}
             Err(e) => {
                 panic!("{:?}", e);
@@ -261,7 +261,7 @@ mod test {
             interval: 2,
             ..Default::default()
         };
-        match e3.set_recurrence(e3rr, &calendar.settings, true) {
+        match e3.set_recurrence(e3rr) {
             Ok(_) => {}
             Err(e) => {
                 panic!("{:?}", e);


### PR DESCRIPTION
### Changed
- [Breaking change] `end_time` now is always the provided `start_time + duration`, and doesn't depend on the recurrence
  - I'm not sure why it was defaulting to changing `end_time` to MAX_UTC for recurring events tbh
  - It makes more sense to have the default event fields contain the correct information about the "first instance", and leave the recurrence stuff (e.g. `until`) in the recurrence field/config


### Notes
- I didn't have to change much in the tests (except removing the parameters), so looks like that behavior wasn't needed either way