### PR TITLE
fix: always use provided data

### DIFF
--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -233,10 +233,11 @@ impl UseCase for UpdateEventUseCase {
         let mut start_or_duration_change = false;
 
         if let Some(start_time) = start_time {
-            e.start_time = *start_time;
+            // Only change the exdates if the start time has actually changed
             if e.start_time != *start_time {
                 e.exdates = Vec::new();
             }
+            e.start_time = *start_time;
             start_or_duration_change = true;
         }
         if let Some(duration) = duration {

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -233,17 +233,15 @@ impl UseCase for UpdateEventUseCase {
         let mut start_or_duration_change = false;
 
         if let Some(start_time) = start_time {
+            e.start_time = *start_time;
             if e.start_time != *start_time {
-                e.start_time = *start_time;
                 e.exdates = Vec::new();
-                start_or_duration_change = true;
             }
+            start_or_duration_change = true;
         }
         if let Some(duration) = duration {
-            if e.duration != *duration {
-                e.duration = *duration;
-                start_or_duration_change = true;
-            }
+            e.duration = *duration;
+            start_or_duration_change = true;
         }
 
         if start_or_duration_change {


### PR DESCRIPTION
### Changed
- Force `start_time` and `duration` to be "updated" even if the values are the same
  - Triggers update of `end_time`
  - (Otherwise, events with a wrong `end_time` are not updated if the `start_time` and `duration` are the same) 