### PR TITLE
feat: allow to override weekstart for specific events

### DIFF
--- a/clients/javascript/lib/gen_types/RRuleOptions.ts
+++ b/clients/javascript/lib/gen_types/RRuleOptions.ts
@@ -6,14 +6,53 @@ import type { WeekDayRecurrence } from './WeekDayRecurrence'
  * Options for recurring events
  */
 export type RRuleOptions = {
+  /**
+   * Frequency of the rule
+   * Default: Daily
+   */
   freq: RRuleFrequency
+  /**
+   * Interval between recurrences
+   */
   interval: number
+  /**
+   * Number of occurrences to generate
+   */
   count?: number
+  /**
+   * End date of the rule (UTC)
+   */
   until?: string
+  /**
+   * Select specific occurrences within a set
+   */
   bysetpos?: Array<number>
+  /**
+   * Select specific weekdays
+   * E.g. `["Mon"]`, `["Mon", "Tue"]`, `["1Mon"]`, `["-1Sun"]`
+   */
   byweekday?: Array<WeekDayRecurrence>
+  /**
+   * Select specific month days
+   */
   bymonthday?: Array<number>
+  /**
+   * Select specific months
+   * E.g. `["January"]`, `["January", "February"]`, `[1, 2]`
+   */
   bymonth?: Array<string>
+  /**
+   * Select specific year days
+   */
   byyearday?: Array<number>
+  /**
+   * Select specific week numbers
+   */
   byweekno?: Array<number>
+  /**
+   * Specify the week start day
+   * Default: CalendarSettings.week_start (Week start configured in the calendar settings)
+   * Possible values: "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"
+   */
+  weekstart?: string
 }

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -215,7 +215,7 @@ describe('CalendarEvent API', () => {
       expect(res.event.endTime.toISOString()).toBe('2024-06-08T18:59:59.999Z')
     })
 
-    it('should be able to create event with recurring schedule', async () => {
+    it('should be able to create events with recurring schedule', async () => {
       const weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
       const res = await adminClient.events.create(userId, {
         calendarId,
@@ -293,6 +293,38 @@ describe('CalendarEvent API', () => {
           until: '2024-10-16T14:59:59Z',
           byweekday: ['Thu'],
           bymonthday: [],
+        })
+      )
+
+      const by3rdFriday = await adminClient.events.create(userId, {
+        calendarId: calendarTokyoId,
+        startTime: dayjs('2022-03-10T09:30:00.000Z').toDate(),
+        duration: 1800000,
+        eventType: 'gcal',
+        recurrence: {
+          freq: 'monthly',
+          interval: 1,
+          count: undefined,
+          until: undefined,
+          bysetpos: undefined,
+          byweekday: ['3Fri'],
+          bymonthday: [],
+          bymonth: undefined,
+          byyearday: undefined,
+          byweekno: undefined,
+          weekstart: 'Sun',
+        },
+      })
+
+      expect(by3rdFriday.event).toBeDefined()
+      expect(by3rdFriday.event.calendarId).toBe(calendarTokyoId)
+      expect(by3rdFriday.event.recurrence).toEqual(
+        expect.objectContaining({
+          freq: 'monthly',
+          interval: 1,
+          byweekday: ['3Fri'],
+          bymonthday: [],
+          weekstart: 'Sun',
         })
       )
     })

--- a/crates/domain/src/shared/recurrence.rs
+++ b/crates/domain/src/shared/recurrence.rs
@@ -24,24 +24,52 @@ pub enum RRuleFrequency {
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct RRuleOptions {
+    /// Frequency of the rule
+    /// Default: Daily
     pub freq: RRuleFrequency,
+
+    /// Interval between recurrences
     pub interval: isize,
+
+    /// Number of occurrences to generate
     #[ts(optional)]
     pub count: Option<i32>,
+
+    /// End date of the rule (UTC)
     #[ts(optional)]
     pub until: Option<DateTime<Utc>>,
+
+    /// Select specific occurrences within a set
     #[ts(optional)]
     pub bysetpos: Option<Vec<isize>>,
+
+    /// Select specific weekdays
+    /// E.g. `["Mon"]`, `["Mon", "Tue"]`, `["1Mon"]`, `["-1Sun"]`
     #[ts(optional)]
     pub byweekday: Option<Vec<WeekDayRecurrence>>,
+
+    /// Select specific month days
     #[ts(optional)]
     pub bymonthday: Option<Vec<isize>>,
+
+    /// Select specific months
+    /// E.g. `["January"]`, `["January", "February"]`, `[1, 2]`
     #[ts(optional)]
     pub bymonth: Option<Vec<Month>>,
+
+    /// Select specific year days
     #[ts(optional)]
     pub byyearday: Option<Vec<isize>>,
+
+    /// Select specific week numbers
     #[ts(optional)]
     pub byweekno: Option<Vec<isize>>,
+
+    /// Specify the week start day
+    /// Default: CalendarSettings.week_start (Week start configured in the calendar settings)
+    /// Possible values: "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"
+    #[ts(optional)]
+    pub weekstart: Option<Weekday>,
 }
 
 fn freq_convert(freq: &RRuleFrequency) -> Frequency {
@@ -144,7 +172,7 @@ impl RRuleOptions {
             .by_hour(vec![dtstart.hour() as u8])
             .by_minute(vec![dtstart.minute() as u8])
             .by_second(vec![dtstart.second() as u8])
-            .week_start(calendar_settings.week_start)
+            .week_start(self.weekstart.unwrap_or(calendar_settings.week_start))
             .interval(self.interval as u16);
 
         if let Some(count) = count {
@@ -172,6 +200,7 @@ impl Default for RRuleOptions {
             bymonth: None,
             byyearday: None,
             byweekno: None,
+            weekstart: None,
         }
     }
 }


### PR DESCRIPTION
### Changed
- Allow to override the week start for specific events (use calendar's settings by default)