### PR TITLE
test(load tests): increase timeout of client

### DIFF
--- a/clients/javascript/tests/helpers/fixtures.ts
+++ b/clients/javascript/tests/helpers/fixtures.ts
@@ -5,17 +5,25 @@ import { readPrivateKey, readPublicKey } from './utils'
 export const CREATE_ACCOUNT_CODE =
   process.env.NITTEI__CREATE_ACCOUNT_SECRET_CODE || 'create_account_dev_secret'
 
-export const setupAccount = async () => {
+export const setupAccount = async (options?: {
+  timeout?: number
+}) => {
   const client = await NitteiClient()
   const account = await client.account.create({ code: CREATE_ACCOUNT_CODE })
   const accountId = account.account.id
   if (!accountId) {
     throw new Error('Account not created')
   }
+
+  const config: Parameters<typeof NitteiClient>[0] = {
+    apiKey: account.secretApiKey,
+  }
+  if (options?.timeout) {
+    config.timeout = options.timeout
+  }
+
   return {
-    client: await NitteiClient({
-      apiKey: account.secretApiKey,
-    }),
+    client: await NitteiClient(config),
     accountId: account.account.id,
   }
 }

--- a/clients/javascript/tests/requirements/loadTests.spec.ts
+++ b/clients/javascript/tests/requirements/loadTests.spec.ts
@@ -57,12 +57,13 @@ async function create200Events(
 
 describe('Load tests', () => {
   let client: INitteiClient | undefined
-  let accountId: string | undefined
 
   beforeAll(async () => {
-    const account = await setupAccount()
+    const account = await setupAccount({
+      // Increase timeout to 3 seconds for load tests
+      timeout: 3000,
+    })
 
-    accountId = account.accountId
     client = account.client
   })
 


### PR DESCRIPTION
### Changed
- Following the reduction of the default timeout of the client from 5s to 1s, the tests in the CI sometimes fail during the load tests on ARM
  - This PR increases it back to 3s (only for load tests)