### PR TITLE
fix: typo with recurring_event_uid

### DIFF
--- a/clients/javascript/tests/account.spec.ts
+++ b/clients/javascript/tests/account.spec.ts
@@ -389,5 +389,24 @@ describe('Account API', () => {
         ])
       )
     })
+
+    it('should be able to search on the recurring event ID directly', async () => {
+      const res = await adminClient.account.searchEventsInAccount({
+        filter: {
+          recurringEventUid: {
+            eq: recurringEventId,
+          },
+        },
+      })
+
+      expect(res.events.length).toBe(1)
+      expect(res.events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: recurringExceptionEventId,
+          }),
+        ])
+      )
+    })
   })
 })

--- a/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -666,7 +666,7 @@ impl IEventRepo for PostgresEventRepo {
 
         apply_id_query(
             &mut query,
-            "recurring_event_uid",
+            "e",
             "recurring_event_uid",
             &params.search_events_params.recurring_event_uid,
         );
@@ -813,7 +813,7 @@ impl IEventRepo for PostgresEventRepo {
 
         apply_id_query(
             &mut query,
-            "recurring_event_uid",
+            "e",
             "recurring_event_uid",
             &params.search_events_params.recurring_event_uid,
         );


### PR DESCRIPTION
### Changed
- Fix a typo when implementing search on `recurring_event_uid`
  - Should have implemented a test 😅  