### PR TITLE
feat: run migrations in init container

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,6 +1,6 @@
 # Usage:
-# docker buildx build -f musl.Dockerfile -t image:tag --build-arg='ARCH=x86_64' --platform linux/amd64 .
-# docker buildx build -f musl.Dockerfile -t image:tag --build-arg='ARCH=aarch64' --platform linux/arm64 .
+# docker buildx build -f alpine.Dockerfile -t image:tag --build-arg='ARCH=x86_64' --platform linux/amd64 .
+# docker buildx build -f alpine.Dockerfile -t image:tag --build-arg='ARCH=aarch64' --platform linux/arm64 .
 
 ARG ARCH=x86_64
 FROM messense/rust-musl-cross:${ARCH}-musl AS builder
@@ -24,6 +24,10 @@ COPY . .
 RUN cargo build --release --target ${ARCH}-unknown-linux-musl && \
   cp ./target/${ARCH}-unknown-linux-musl/release/${APP_NAME} /${APP_NAME}
 
+# Build migrate binary
+RUN cargo build --release --bin nittei-migrate --target ${ARCH}-unknown-linux-musl && \
+  cp ./target/${ARCH}-unknown-linux-musl/release/nittei-migrate /nittei-migrate
+
 #Create a new stage with a minimal image
 FROM alpine:3.20.3
 
@@ -31,5 +35,6 @@ ARG APP_NAME=nittei
 ENV APP_NAME=${APP_NAME}
 
 COPY --from=builder /${APP_NAME} /${APP_NAME}
+COPY --from=builder /nittei-migrate /nittei-migrate
 
 CMD ["/bin/sh", "-c", "exec /${APP_NAME}"]

--- a/alpineWithDD.Dockerfile
+++ b/alpineWithDD.Dockerfile
@@ -27,6 +27,10 @@ COPY . .
 RUN cargo build --release --target ${ARCH}-unknown-linux-musl && \
   cp ./target/${ARCH}-unknown-linux-musl/release/${APP_NAME} /${APP_NAME}
 
+# Build migrate binary
+RUN cargo build --release --bin nittei-migrate --target ${ARCH}-unknown-linux-musl && \
+  cp ./target/${ARCH}-unknown-linux-musl/release/nittei-migrate /nittei-migrate
+
 # Install ddprof
 RUN ARCH_IN_URL=$(case "${ARCH}" in \
   x86_64) echo "amd64" ;; \
@@ -44,6 +48,7 @@ ARG APP_NAME=nittei
 ENV APP_NAME=${APP_NAME}
 
 COPY --from=builder /${APP_NAME} /${APP_NAME}
+COPY --from=builder /nittei-migrate /nittei-migrate
 COPY --from=builder /ddprof /ddprof
 
 CMD ["/bin/sh", "-c", "exec /ddprof --preset cpu_live_heap /${APP_NAME}"]

--- a/bins/nittei/Cargo.toml
+++ b/bins/nittei/Cargo.toml
@@ -5,6 +5,18 @@ authors = ["Fredrik Meringdal", "Meetsmore"]
 edition = "2024"
 default-run = "nittei"
 
+[lib]
+name = "nittei"
+path = "src/lib.rs"
+
+[[bin]]
+name = "nittei"
+path = "src/main.rs"
+
+[[bin]]
+name = "nittei-migrate"
+path = "src/bin/migrate.rs"
+
 [lints]
 workspace = true
 

--- a/bins/nittei/src/bin/migrate.rs
+++ b/bins/nittei/src/bin/migrate.rs
@@ -1,6 +1,18 @@
+use nittei::telemetry::init_subscriber;
 use nittei_infra::run_migration;
+use tracing::{error, info};
 
+/// This is a standalone binary that can be run to apply the migrations
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    run_migration().await
+    // Initialize the subscriber for logging & tracing
+    init_subscriber()?;
+
+    run_migration().await.inspect_err(|e| {
+        error!("Failed to run migrations: {}", e);
+    })?;
+
+    info!("Migrations complete");
+
+    Ok(())
 }

--- a/bins/nittei/src/lib.rs
+++ b/bins/nittei/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod telemetry;

--- a/bins/nittei/src/main.rs
+++ b/bins/nittei/src/main.rs
@@ -1,8 +1,6 @@
-mod telemetry;
-
+use nittei::telemetry::init_subscriber;
 use nittei_api::Application;
 use nittei_infra::setup_context;
-use telemetry::init_subscriber;
 use tikv_jemallocator::Jemalloc;
 use tokio::signal;
 use tracing::{error, info};

--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -85,10 +85,14 @@ spec:
               valueFrom: {{ toYaml $value.valueFrom | nindent 16 }}
               {{- end }}
             {{- end }}
+          {{ if .Values.migrationInitContainer.command }}
+          command: {{ .Values.migrationInitContainer.command }}
+          {{- else }}
           command:
             - /bin/sh
             - -c
-            - "/nittei-migrate"
+            - "exec /nittei-migrate"
+          {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -63,6 +63,33 @@ spec:
       serviceAccountName: {{ include "nittei.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{ if .Values.migrationInitContainer.enabled }}
+      initContainers:
+        - name: {{ .Chart.Name }}-migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.initContainer.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- range $key, $value := $envMap }}
+            - name: {{ $key }}
+              {{- if hasKey $value "value" }}
+              value: {{ $value.value | quote }}
+              {{- else if hasKey $value "valueFrom" }}
+              valueFrom: {{ toYaml $value.valueFrom | nindent 16 }}
+              {{- end }}
+            {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - "/nittei-migrate"
+          {{- with .Values.initContainer.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -69,9 +69,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            {{- toYaml .Values.initContainer.securityContext | nindent 12 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- range $key, $value := $envMap }}
             - name: {{ $key }}
@@ -85,10 +89,6 @@ spec:
             - /bin/sh
             - -c
             - "/nittei-migrate"
-          {{- with .Values.initContainer.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/nittei/values.yaml
+++ b/charts/nittei/values.yaml
@@ -23,6 +23,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+migrationInitContainer:
+  enabled: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/nittei/values.yaml
+++ b/charts/nittei/values.yaml
@@ -25,6 +25,7 @@ fullnameOverride: ""
 
 migrationInitContainer:
   enabled: false
+  command: []
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -24,7 +24,9 @@ RUN --mount=type=bind,source=bins,target=/app/${APP_NAME}/bins \
   --mount=type=cache,target=/usr/local/cargo/git/db \
   --mount=type=cache,target=/usr/local/cargo/registry/ \
   cargo build --locked --release && \
-  cp ./target/release/$APP_NAME /bin/server
+  cp ./target/release/$APP_NAME /nittei && \
+  cargo build --locked --release --bin nittei-migrate && \
+  cp ./target/release/nittei-migrate /nittei-migrate
 
 FROM debian:stable-slim
 
@@ -47,6 +49,7 @@ RUN adduser \
   appuser
 USER appuser
 
-COPY --from=builder /bin/server /bin/
+COPY --from=builder /nittei /nittei
+COPY --from=builder /nittei-migrate /nittei-migrate
 
-CMD ["/bin/server"]
+CMD ["/nittei"]

--- a/debianWithDD.Dockerfile
+++ b/debianWithDD.Dockerfile
@@ -29,7 +29,9 @@ RUN --mount=type=bind,source=bins,target=/app/${APP_NAME}/bins \
   --mount=type=cache,target=/usr/local/cargo/git/db \
   --mount=type=cache,target=/usr/local/cargo/registry/ \
   cargo build --locked --release && \
-  cp ./target/release/$APP_NAME /bin/server
+  cp ./target/release/$APP_NAME /nittei && \
+  cargo build --locked --release --bin nittei-migrate && \
+  cp ./target/release/nittei-migrate /nittei-migrate
 
 # Install ddprof
 RUN ARCH_IN_URL=$(case "${ARCH}" in \
@@ -62,7 +64,8 @@ RUN adduser \
   appuser
 USER appuser
 
-COPY --from=builder /bin/server /bin/
+COPY --from=builder /nittei /nittei
+COPY --from=builder /nittei-migrate /nittei-migrate
 COPY --from=builder /ddprof /ddprof
 
-CMD ["/ddprof", "--preset", "cpu_live_heap", "/bin/server"]
+CMD ["/ddprof", "--preset", "cpu_live_heap", "/nittei"]


### PR DESCRIPTION
### Problem
- SQL migrations can take some time, which makes the app unavailable to probes
  - Application crashes and restarts, without finishing migration
  - Crashloop

### Changed
- Helm chart: allow to run SQL migrations via an initContainer
- Improve binary for running migrations