### PR TITLE
fix: convert recurringUntil to date

### DIFF
--- a/clients/javascript/lib/helpers/datesConverters.ts
+++ b/clients/javascript/lib/helpers/datesConverters.ts
@@ -16,6 +16,9 @@ export function convertEventDates(event: CalendarEventDTO): CalendarEventDTO {
     endTime: new Date(event.endTime),
     created: new Date(event.created),
     updated: new Date(event.updated),
+    recurringUntil: event.recurringUntil
+      ? new Date(event.recurringUntil)
+      : undefined,
     exdates: event.exdates?.map(date => new Date(date)),
   }
 }

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -255,6 +255,9 @@ describe('CalendarEvent API', () => {
 
       expect(resEventTokyo.event).toBeDefined()
       expect(resEventTokyo.event.calendarId).toBe(calendarTokyoId)
+      expect(resEventTokyo.event.recurringUntil).toEqual(
+        dayjs('2024-12-12T14:59:59.000Z').toDate()
+      )
       expect(resEventTokyo.event.recurrence).toEqual(
         expect.objectContaining({
           freq: 'weekly',


### PR DESCRIPTION
### Changed
- Convert `recurringUntil` to a Date in JS