### PR TITLE
fix: add duration to recurring_until

### DIFF
--- a/clients/javascript/lib/gen_types/CalendarEventDTO.ts
+++ b/clients/javascript/lib/gen_types/CalendarEventDTO.ts
@@ -84,6 +84,7 @@ export type CalendarEventDTO = {
   /**
    * Optional recurring until date
    * This is the date until which the event will recur
+   * This is calculated by adding the duration to the until date
    */
   recurringUntil?: Date
   /**

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -241,7 +241,7 @@ describe('CalendarEvent API', () => {
 
       const resEventTokyo = await adminClient.events.create(userId, {
         calendarId: calendarTokyoId,
-        duration: 1800000,
+        duration: 1800000, // 30 minutes
         startTime: dayjs('2024-11-29T07:00:00.000Z').toDate(),
         eventType: 'gcal',
         recurrence: {
@@ -256,7 +256,7 @@ describe('CalendarEvent API', () => {
       expect(resEventTokyo.event).toBeDefined()
       expect(resEventTokyo.event.calendarId).toBe(calendarTokyoId)
       expect(resEventTokyo.event.recurringUntil).toEqual(
-        dayjs('2024-12-12T14:59:59.000Z').toDate()
+        dayjs('2024-12-12T15:29:59.000Z').toDate() // 30 minutes after until
       )
       expect(resEventTokyo.event.recurrence).toEqual(
         expect.objectContaining({

--- a/crates/api_structs/src/event/dtos.rs
+++ b/crates/api_structs/src/event/dtos.rs
@@ -85,6 +85,7 @@ pub struct CalendarEventDTO {
 
     /// Optional recurring until date
     /// This is the date until which the event will recur
+    /// This is calculated by adding the duration to the until date
     #[ts(optional, type = "Date")]
     pub recurring_until: Option<DateTime<Utc>>,
 

--- a/crates/domain/src/event.rs
+++ b/crates/domain/src/event.rs
@@ -157,7 +157,12 @@ impl CalendarEvent {
             return Ok(false);
         }
 
-        self.recurring_until = recurrence.until;
+        // Add duration to until if it is set
+        self.recurring_until = recurrence
+            .until
+            .map(|until| until + TimeDelta::milliseconds(self.duration));
+
+        // Set the recurrence
         self.recurrence = Some(recurrence);
         Ok(true)
     }


### PR DESCRIPTION
### Changed
- Add `duration` to the `recurring_until` field when computed, as otherwise doing `timespan.start < recurring_until` can miss some events if `recurring_until  === timespan.start`

