### PR TITLE
feat: use thin lto when building for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ print_stdout = "deny"
 print_err = "deny"
 unwrap_used = "deny"
 expect_used = "deny"
+
+[profile.release]
+# Can improve slightly the performance at the cost of increased compile time
+# https://doc.rust-lang.org/cargo/reference/profiles.html#lto
+lto = "thin"


### PR DESCRIPTION
### Changed
- Use `lto = "thin"` as an option when building for release
  - It can slightly improve the performance, at the cost of slightly longer compile time
  - https://doc.rust-lang.org/cargo/reference/profiles.html#lto
  - Used by tikv: https://github.com/tikv/tikv/blob/master/Cargo.toml#L435
  - Used by linkerd: https://github.com/linkerd/linkerd2/blob/main/Cargo.toml#L15