### PR TITLE
fix: increase default query duration

### DIFF
--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -874,14 +874,14 @@ describe('CalendarEvent API', () => {
         duration: 1000,
         status: 'confirmed',
         busy: true,
-        startTime: new Date(1000),
+        startTime: new Date('2025-04-10T00:00:00.000Z'),
       })
       eventId1 = eventRes1.event.id
 
       const eventRes2 = await adminClient.events.create(userId, {
         calendarId,
         duration: 50,
-        startTime: new Date(50),
+        startTime: new Date('2025-04-11T00:00:00.000Z'),
         status: 'confirmed',
         busy: true,
         recurrence: {
@@ -895,8 +895,8 @@ describe('CalendarEvent API', () => {
     it('should be able to get events of users during timespan, with recurrence', async () => {
       const res = await adminClient.events.getEventsOfUsersDuringTimespan({
         userIds: [userId],
-        startTime: new Date(1000),
-        endTime: new Date(2000),
+        startTime: new Date('2025-04-09T00:00:00.000Z'),
+        endTime: new Date('2025-11-09T00:00:00.000Z'),
       })
 
       expect(res.events.length).toBe(2)

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -53,7 +53,7 @@ pub struct AppConfig {
     /// This is used to avoid having clients ask for `CalendarEvents` in a
     /// timespan of several years which will take a lot of time to compute
     /// and is also not very useful information to query about anyways.
-    /// Default is 200 days
+    /// Default is 300 days
     /// Env var: NITTEI__EVENT_INSTANCES_QUERY_DURATION_LIMIT
     pub event_instances_query_duration_limit: i64,
 
@@ -208,7 +208,7 @@ fn parse_config() -> AppConfig {
         .expect("Failed to set default max_events_returned_by_search")
         .set_default(
             "event_instances_query_duration_limit",
-            200_i64 * 24 * 60 * 60 * 1000, // 200 days
+            300_i64 * 24 * 60 * 60 * 1000, // 300 days
         )
         .expect("Failed to set default event_instances_query_duration_limit")
         .set_default(


### PR DESCRIPTION
### Changed
- Increased default duration limit from 200 days to 300 days
  - Needed for us