### PR TITLE
fix(tracing): otel.name

### DIFF
--- a/crates/api/src/http_logger.rs
+++ b/crates/api/src/http_logger.rs
@@ -75,7 +75,7 @@ impl<B> MakeSpan<B> for NitteiTracingSpanBuilder {
             url.path = %path,
             url.query = %query,
             url.scheme = request.uri().scheme_str().unwrap_or("http"),
-            otel.name = %format!("{} {}", http_method, path),
+            otel.name = %format!("{} {}", http_method, matched_path),
             otel.kind = ?opentelemetry::trace::SpanKind::Server,
             otel.status_code = Empty, // to set on response
             resource.name = %matched_path,


### PR DESCRIPTION
### Changed
- Try to fix resource name used by Datadog for grouping calls together
  - Right now, DD manages to group paths that have UUIDs, but not the ones with ObjectIds
  - This PR uses the `matched_path` which contains the generic version `/{id}` instead of `/some-id`