### PR TITLE
refactor(debian): change to distroless and add more optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,4 @@ expect_used = "deny"
 # Can improve slightly the performance at the cost of increased compile time
 # https://doc.rust-lang.org/cargo/reference/profiles.html#lto
 lto = "thin"
-opt-level = 3
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ expect_used = "deny"
 # Can improve slightly the performance at the cost of increased compile time
 # https://doc.rust-lang.org/cargo/reference/profiles.html#lto
 lto = "thin"
+opt-level = 3
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ expect_used = "deny"
 # Can improve slightly the performance at the cost of increased compile time
 # https://doc.rust-lang.org/cargo/reference/profiles.html#lto
 lto = "thin"
+# https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units
 codegen-units = 1

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -28,28 +28,15 @@ RUN --mount=type=bind,source=bins,target=/app/${APP_NAME}/bins \
   cargo build --locked --release --bin nittei-migrate && \
   cp ./target/release/nittei-migrate /nittei-migrate
 
-FROM debian:stable-slim
+# Use the distroless base image for final image
+FROM gcr.io/distroless/cc-debian12
 
 # Enable backtraces
 ENV RUST_BACKTRACE=1
 
-RUN apt update \
-  && apt install -y openssl ca-certificates \
-  && apt clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+USER nonroot:nonroot
 
-ARG UID=10001
-RUN adduser \
-  --disabled-password \
-  --gecos "" \
-  --home "/nonexistent" \
-  --shell "/sbin/nologin" \
-  --no-create-home \
-  --uid "${UID}" \
-  appuser
-USER appuser
-
-COPY --from=builder /nittei /nittei
-COPY --from=builder /nittei-migrate /nittei-migrate
+COPY --from=builder --chown=nonroot:nonroot /nittei /nittei
+COPY --from=builder --chown=nonroot:nonroot /nittei-migrate /nittei-migrate
 
 CMD ["/nittei"]

--- a/debianWithDD.Dockerfile
+++ b/debianWithDD.Dockerfile
@@ -43,29 +43,16 @@ RUN ARCH_IN_URL=$(case "${ARCH}" in \
   tar xvf ddprof-linux.tar.xz && \
   mv ddprof/bin/ddprof /ddprof
 
-FROM debian:stable-slim
+# Use the distroless base image for final image
+FROM gcr.io/distroless/cc-debian12
 
 # Enable backtraces
 ENV RUST_BACKTRACE=1
 
-RUN apt update \
-  && apt install -y openssl ca-certificates \
-  && apt clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+USER nonroot:nonroot
 
-ARG UID=10001
-RUN adduser \
-  --disabled-password \
-  --gecos "" \
-  --home "/nonexistent" \
-  --shell "/sbin/nologin" \
-  --no-create-home \
-  --uid "${UID}" \
-  appuser
-USER appuser
-
-COPY --from=builder /nittei /nittei
-COPY --from=builder /nittei-migrate /nittei-migrate
-COPY --from=builder /ddprof /ddprof
+COPY --from=builder --chown=nonroot:nonroot /nittei /nittei
+COPY --from=builder --chown=nonroot:nonroot /nittei-migrate /nittei-migrate
+COPY --from=builder --chown=nonroot:nonroot /ddprof /ddprof
 
 CMD ["/ddprof", "--preset", "cpu_live_heap", "/nittei"]


### PR DESCRIPTION
### Changed
- Configure `codegen-units` which allows more optimizations to be made at the cost of compile time (let's see how much)
- Change Debian Docker images from `slim` to distroless, as we only need `glibc`