### PR TITLE
refactor: use middleware for admin routes

### DIFF
--- a/crates/api/src/account/account_search_events.rs
+++ b/crates/api/src/account/account_search_events.rs
@@ -1,16 +1,21 @@
-use axum::{Extension, Json, http::HeaderMap};
+use axum::{Extension, Json};
 use axum_valid::Valid;
 use nittei_api_structs::{account_search_events::*, dtos::CalendarEventDTO};
-use nittei_domain::{CalendarEventSort, DateTimeQuery, ID, IDQuery, RecurrenceQuery, StringQuery};
+use nittei_domain::{
+    Account,
+    CalendarEventSort,
+    DateTimeQuery,
+    ID,
+    IDQuery,
+    RecurrenceQuery,
+    StringQuery,
+};
 use nittei_infra::{NitteiContext, SearchEventsForAccountParams, SearchEventsParams};
 use nittei_utils::config::APP_CONFIG;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -30,12 +35,10 @@ use crate::{
 )]
 /// Search events inside an account
 pub async fn account_search_events_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<AccountSearchEventsRequestBody>>,
 ) -> Result<Json<SearchEventsAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let mut body = body.0;
     let usecase = AccountSearchEventsUseCase {
         account_uid: account.id,

--- a/crates/api/src/account/add_account_integration.rs
+++ b/crates/api/src/account/add_account_integration.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Json, http::HeaderMap};
+use axum::{Extension, Json};
 use axum_valid::Valid;
 use nittei_api_structs::add_account_integration::{APIResponse, AddAccountIntegrationRequestBody};
 use nittei_domain::{Account, AccountIntegration, IntegrationProvider};
@@ -6,10 +6,7 @@ use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -28,12 +25,10 @@ use crate::{
     )
 )]
 pub async fn add_account_integration_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<AddAccountIntegrationRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let body = body.0;
     let usecase = AddAccountIntegrationUseCase {
         account,

--- a/crates/api/src/account/delete_account_webhook.rs
+++ b/crates/api/src/account/delete_account_webhook.rs
@@ -1,12 +1,10 @@
-use axum::{Extension, Json, http::HeaderMap};
+use axum::{Extension, Json};
 use nittei_api_structs::delete_account_webhook::APIResponse;
+use nittei_domain::Account;
 use nittei_infra::NitteiContext;
 
 use super::set_account_webhook::SetAccountWebhookUseCase;
-use crate::{
-    error::NitteiError,
-    shared::{auth::protect_admin_route, usecase::execute},
-};
+use crate::{error::NitteiError, shared::usecase::execute};
 
 #[utoipa::path(
     delete,
@@ -21,11 +19,9 @@ use crate::{
     )
 )]
 pub async fn delete_account_webhook_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = SetAccountWebhookUseCase {
         account,
         webhook_url: None,

--- a/crates/api/src/account/get_account.rs
+++ b/crates/api/src/account/get_account.rs
@@ -1,8 +1,9 @@
-use axum::{Extension, Json, http::HeaderMap};
+use axum::{Extension, Json};
 use nittei_api_structs::get_account::APIResponse;
+use nittei_domain::Account;
 use nittei_infra::NitteiContext;
 
-use crate::{error::NitteiError, shared::auth::protect_admin_route};
+use crate::error::NitteiError;
 
 #[utoipa::path(
     get,
@@ -17,11 +18,9 @@ use crate::{error::NitteiError, shared::auth::protect_admin_route};
     )
 )]
 pub async fn get_account_controller(
-    headers: HeaderMap,
     Extension(ctx): Extension<NitteiContext>,
+    Extension(account_possibly_stale): Extension<Account>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account_possibly_stale = protect_admin_route(&headers, &ctx).await?;
-
     // Refetch the account, as the protect_admin_route uses a cached method
     // Meaning that the account could have been deleted in the meantime (or updated)
     let account = ctx

--- a/crates/api/src/account/remove_account_integration.rs
+++ b/crates/api/src/account/remove_account_integration.rs
@@ -1,14 +1,11 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::remove_account_integration::{APIResponse, PathParams};
 use nittei_domain::{Account, IntegrationProvider};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -27,12 +24,10 @@ use crate::{
     )
 )]
 pub async fn remove_account_integration_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = RemoveAccountIntegrationUseCase {
         account,
         provider: std::mem::take(&mut path.provider),

--- a/crates/api/src/account/set_account_pub_key.rs
+++ b/crates/api/src/account/set_account_pub_key.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Json, http::HeaderMap};
+use axum::{Extension, Json};
 use axum_valid::Valid;
 use nittei_api_structs::set_account_pub_key::{APIResponse, SetAccountPubKeyRequestBody};
 use nittei_domain::{Account, PEMKey};
@@ -6,10 +6,7 @@ use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -28,12 +25,10 @@ use crate::{
     )
 )]
 pub async fn set_account_pub_key_controller(
-    headers: HeaderMap,
     Extension(ctx): Extension<NitteiContext>,
+    Extension(account): Extension<Account>,
     body: Valid<Json<SetAccountPubKeyRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = SetAccountPubKeyUseCase {
         account,
         public_jwt_key: body.public_jwt_key.clone(),

--- a/crates/api/src/account/set_account_webhook.rs
+++ b/crates/api/src/account/set_account_webhook.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Json, http::HeaderMap};
+use axum::{Extension, Json};
 use axum_valid::Valid;
 use nittei_api_structs::set_account_webhook::{APIResponse, SetAccountWebhookRequestBody};
 use nittei_domain::Account;
@@ -6,10 +6,7 @@ use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -28,12 +25,10 @@ use crate::{
     )
 )]
 pub async fn set_account_webhook_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<SetAccountWebhookRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = SetAccountWebhookUseCase {
         account,
         webhook_url: Some(body.webhook_url.clone()),

--- a/crates/api/src/calendar/add_sync_calendar.rs
+++ b/crates/api/src/calendar/add_sync_calendar.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use axum_valid::Valid;
 use nittei_api_structs::add_sync_calendar::{
     APIResponse,
@@ -6,6 +6,7 @@ use nittei_api_structs::add_sync_calendar::{
     AddSyncCalendarRequestBody,
 };
 use nittei_domain::{
+    Account,
     ID,
     IntegrationProvider,
     SyncedCalendar,
@@ -21,7 +22,7 @@ use nittei_infra::{
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_admin_route},
+        auth::{Permission, account_can_modify_user},
         usecase::{PermissionBoundary, UseCase, execute},
     },
 };
@@ -45,12 +46,11 @@ use crate::{
     )
 )]
 pub async fn add_sync_calendar_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<AddSyncCalendarPathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<AddSyncCalendarRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let user = account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 
     let body = body.0;

--- a/crates/api/src/calendar/create_calendar.rs
+++ b/crates/api/src/calendar/create_calendar.rs
@@ -8,13 +8,13 @@ use axum_valid::Valid;
 use chrono::Weekday;
 use chrono_tz::Tz;
 use nittei_api_structs::create_calendar::{APIResponse, CreateCalendarRequestBody, PathParams};
-use nittei_domain::{Calendar, CalendarSettings, ID};
+use nittei_domain::{Account, Calendar, CalendarSettings, ID};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_admin_route, protect_route},
+        auth::{Permission, account_can_modify_user, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -35,12 +35,11 @@ use crate::{
     )
 )]
 pub async fn create_calendar_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     mut body: Valid<Json<CreateCalendarRequestBody>>,
 ) -> Result<(StatusCode, Json<APIResponse>), NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let user = account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 
     let usecase = CreateCalendarUseCase {

--- a/crates/api/src/calendar/delete_calendar.rs
+++ b/crates/api/src/calendar/delete_calendar.rs
@@ -1,12 +1,12 @@
 use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use nittei_api_structs::delete_calendar::{APIResponse, PathParams};
-use nittei_domain::{Calendar, ID};
+use nittei_domain::{Account, Calendar, ID};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_calendar, protect_admin_route, protect_route},
+        auth::{Permission, account_can_modify_calendar, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -27,11 +27,10 @@ use crate::{
     )
 )]
 pub async fn delete_calendar_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let cal = account_can_modify_calendar(&account, &path.calendar_id, &ctx).await?;
 
     let usecase = DeleteCalendarUseCase {

--- a/crates/api/src/calendar/get_calendar.rs
+++ b/crates/api/src/calendar/get_calendar.rs
@@ -1,12 +1,12 @@
 use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use nittei_api_structs::get_calendar::{APIResponse, PathParams};
-use nittei_domain::{Calendar, ID};
+use nittei_domain::{Account, Calendar, ID};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_calendar, protect_admin_route, protect_route},
+        auth::{account_can_modify_calendar, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -27,11 +27,10 @@ use crate::{
     )
 )]
 pub async fn get_calendar_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let cal = account_can_modify_calendar(&account, &path.calendar_id, &ctx).await?;
 
     let usecase = GetCalendarUseCase {

--- a/crates/api/src/calendar/get_calendar_events.rs
+++ b/crates/api/src/calendar/get_calendar_events.rs
@@ -11,6 +11,7 @@ use nittei_api_structs::get_calendar_events::{
     QueryParams,
 };
 use nittei_domain::{
+    Account,
     Calendar,
     EventWithInstances,
     ID,
@@ -25,7 +26,7 @@ use tracing::error;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_calendar, protect_admin_route, protect_route},
+        auth::{account_can_modify_calendar, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -48,12 +49,11 @@ use crate::{
     )
 )]
 pub async fn get_calendar_events_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     query_params: Query<QueryParams>,
     path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetCalendarEventsAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let cal = account_can_modify_calendar(&account, &path.calendar_id, &ctx).await?;
 
     let usecase = GetCalendarEventsUseCase {

--- a/crates/api/src/calendar/get_calendars.rs
+++ b/crates/api/src/calendar/get_calendars.rs
@@ -15,7 +15,7 @@ use nittei_infra::NitteiContext;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{protect_admin_route, protect_route},
+        auth::protect_route,
         usecase::{UseCase, execute},
     },
 };
@@ -37,13 +37,10 @@ use crate::{
     )
 )]
 pub async fn get_calendars_admin_controller(
-    headers: HeaderMap,
     query: Query<QueryParams>,
     path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetCalendarsByUserAPIResponse>, NitteiError> {
-    let _account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = GetCalendarsUseCase {
         user_id: path.user_id.clone(),
         key: query.key.clone(),

--- a/crates/api/src/calendar/get_calendars_by_meta.rs
+++ b/crates/api/src/calendar/get_calendars_by_meta.rs
@@ -1,9 +1,9 @@
-use axum::{Extension, Json, extract::Query, http::HeaderMap};
+use axum::{Extension, Json, extract::Query};
 use nittei_api_structs::get_calendars_by_meta::*;
-use nittei_domain::Metadata;
+use nittei_domain::{Account, Metadata};
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_admin_route};
+use crate::error::NitteiError;
 
 #[utoipa::path(
     get,
@@ -24,12 +24,10 @@ use crate::{error::NitteiError, shared::auth::protect_admin_route};
     )
 )]
 pub async fn get_calendars_by_meta_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     query_params: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetCalendarsByMetaAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let query = MetadataFindQuery {
         account_id: account.id,
         metadata: Metadata::new_kv(query_params.0.key, query_params.0.value),

--- a/crates/api/src/calendar/get_google_calendars.rs
+++ b/crates/api/src/calendar/get_google_calendars.rs
@@ -10,6 +10,7 @@ use nittei_api_structs::get_google_calendars::{
     QueryParams,
 };
 use nittei_domain::{
+    Account,
     ID,
     User,
     providers::google::{GoogleCalendarAccessRole, GoogleCalendarListEntry},
@@ -19,7 +20,7 @@ use nittei_infra::{NitteiContext, google_calendar::GoogleCalendarProvider};
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_user, protect_admin_route, protect_route},
+        auth::{account_can_modify_user, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -41,12 +42,11 @@ use crate::{
     )
 )]
 pub async fn get_google_calendars_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path: Path<PathParams>,
     query: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetGoogleCalendarsAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let user = account_can_modify_user(&account, &path.user_id, &ctx).await?;
 
     let usecase = GetGoogleCalendarsUseCase {

--- a/crates/api/src/calendar/get_outlook_calendars.rs
+++ b/crates/api/src/calendar/get_outlook_calendars.rs
@@ -10,6 +10,7 @@ use nittei_api_structs::get_outlook_calendars::{
     QueryParams,
 };
 use nittei_domain::{
+    Account,
     ID,
     User,
     providers::outlook::{OutlookCalendar, OutlookCalendarAccessRole},
@@ -19,7 +20,7 @@ use nittei_infra::{NitteiContext, outlook_calendar::OutlookCalendarProvider};
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_user, protect_admin_route, protect_route},
+        auth::{account_can_modify_user, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -41,12 +42,11 @@ use crate::{
     )
 )]
 pub async fn get_outlook_calendars_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path: Path<PathParams>,
     query: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetOutlookCalendarsAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let user = account_can_modify_user(&account, &path.user_id, &ctx).await?;
 
     let usecase = GetOutlookCalendarsUseCase {

--- a/crates/api/src/calendar/mod.rs
+++ b/crates/api/src/calendar/mod.rs
@@ -29,58 +29,79 @@ use remove_sync_calendar::remove_sync_calendar_admin_controller;
 use update_calendar::{update_calendar_admin_controller, update_calendar_controller};
 use utoipa_axum::router::OpenApiRouter;
 
+use crate::shared::auth;
+
 /// Configure the routes for the calendar module
 pub fn configure_routes() -> OpenApiRouter {
-    OpenApiRouter::new()
-        // Create a calendar
-        .route("/calendar", post(create_calendar_controller))
+    let admin_router = OpenApiRouter::new()
         // Create a calendar for a user (admin route)
         .route(
             "/user/{user_id}/calendar",
             post(create_calendar_admin_controller),
         )
-        // List calendars
-        .route("/calendar", get(get_calendars::get_calendars_controller))
         // List calendars for a user (admin route)
         .route(
             "/user/{user_id}/calendar",
             get(get_calendars::get_calendars_admin_controller),
         )
-        // List calendars by metadata
+        // List calendars by metadata (admin route)
         .route("/calendar/meta", get(get_calendars_by_meta_controller))
-        // Get a specific calendar by uid
-        .route("/calendar/{calendar_id}", get(get_calendar_controller))
         // Get a specific calendar by uid for a user (admin route)
         .route(
             "/user/calendar/{calendar_id}",
             get(get_calendar_admin_controller),
-        )
-        // Delete a calendar by uid
-        .route(
-            "/calendar/{calendar_id}",
-            delete(delete_calendar_controller),
         )
         // Delete a calendar by uid for a user (admin route)
         .route(
             "/user/calendar/{calendar_id}",
             delete(delete_calendar_admin_controller),
         )
-        // Update a calendar by uid
-        .route("/calendar/{calendar_id}", put(update_calendar_controller))
         // Update a calendar by uid for a user (admin route)
         .route(
             "/user/calendar/{calendar_id}",
             put(update_calendar_admin_controller),
         )
-        // Get events for a calendar
-        .route(
-            "/calendar/{calendar_id}/events",
-            get(get_calendar_events_controller),
-        )
         // Get events for a calendar for a user (admin route)
         .route(
             "/user/calendar/{calendar_id}/events",
             get(get_calendar_events_admin_controller),
+        )
+        .route(
+            "/user/{user_id}/calendar/provider/google",
+            get(get_google_calendars_admin_controller),
+        )
+        .route(
+            "/user/{user_id}/calendar/provider/outlook",
+            get(get_outlook_calendars_admin_controller),
+        )
+        .route(
+            "/user/{user_id}/calendar/sync",
+            put(add_sync_calendar_admin_controller),
+        )
+        .route(
+            "/user/{user_id}/calendar/sync",
+            delete(remove_sync_calendar_admin_controller),
+        )
+        .route_layer(axum::middleware::from_fn(auth::protect_admin_route));
+
+    let user_router = OpenApiRouter::new()
+        // Create a calendar
+        .route("/calendar", post(create_calendar_controller))
+        // List calendars
+        .route("/calendar", get(get_calendars::get_calendars_controller))
+        // Get a specific calendar by uid
+        .route("/calendar/{calendar_id}", get(get_calendar_controller))
+        // Delete a calendar by uid
+        .route(
+            "/calendar/{calendar_id}",
+            delete(delete_calendar_controller),
+        )
+        // Update a calendar by uid
+        .route("/calendar/{calendar_id}", put(update_calendar_controller))
+        // Get events for a calendar
+        .route(
+            "/calendar/{calendar_id}/events",
+            get(get_calendar_events_controller),
         )
         // Calendar providers
         .route(
@@ -88,31 +109,9 @@ pub fn configure_routes() -> OpenApiRouter {
             get(get_google_calendars_controller),
         )
         .route(
-            "/user/{user_id}/calendar/provider/google",
-            get(get_google_calendars_admin_controller),
-        )
-        .route(
             "/calendar/provider/outlook",
             get(get_outlook_calendars_controller),
-        )
-        .route(
-            "/user/{user_id}/calendar/provider/outlook",
-            get(get_outlook_calendars_admin_controller),
-        )
-        // cfg.route(
-        //     "/calendar/sync/",
-        //     web::put().to(add_sync_calendar_controller),
-        // )
-        .route(
-            "/user/{user_id}/calendar/sync",
-            put(add_sync_calendar_admin_controller),
-        )
-        // cfg.route(
-        //     "/calendar/sync",
-        //     web::delete().to(remove_sync_calendar_controller),
-        // )
-        .route(
-            "/user/{user_id}/calendar/sync",
-            delete(remove_sync_calendar_admin_controller),
-        )
+        );
+
+    OpenApiRouter::new().merge(admin_router).merge(user_router)
 }

--- a/crates/api/src/calendar/remove_sync_calendar.rs
+++ b/crates/api/src/calendar/remove_sync_calendar.rs
@@ -1,17 +1,17 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use axum_valid::Valid;
 use nittei_api_structs::remove_sync_calendar::{
     APIResponse,
     RemoveSyncCalendarPathParams,
     RemoveSyncCalendarRequestBody,
 };
-use nittei_domain::{ID, IntegrationProvider};
+use nittei_domain::{Account, ID, IntegrationProvider};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_admin_route},
+        auth::{Permission, account_can_modify_user},
         usecase::{PermissionBoundary, UseCase, execute},
     },
 };
@@ -44,12 +44,11 @@ fn error_handler(e: UseCaseError) -> NitteiError {
     )
 )]
 pub async fn remove_sync_calendar_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<RemoveSyncCalendarPathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<RemoveSyncCalendarRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     // Check if user exists and can be modified by the account
     account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 

--- a/crates/api/src/calendar/update_calendar.rs
+++ b/crates/api/src/calendar/update_calendar.rs
@@ -3,19 +3,13 @@ use axum_valid::Valid;
 use chrono::Weekday;
 use chrono_tz::Tz;
 use nittei_api_structs::update_calendar::{APIResponse, PathParams, UpdateCalendarRequestBody};
-use nittei_domain::{Calendar, ID, User};
+use nittei_domain::{Account, Calendar, ID, User};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{
-            Permission,
-            account_can_modify_calendar,
-            account_can_modify_user,
-            protect_admin_route,
-            protect_route,
-        },
+        auth::{Permission, account_can_modify_calendar, account_can_modify_user, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -39,12 +33,11 @@ use crate::{
     )
 )]
 pub async fn update_calendar_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     path: Path<PathParams>,
     mut body: Valid<Json<UpdateCalendarRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let cal = account_can_modify_calendar(&account, &path.calendar_id, &ctx).await?;
     let user = account_can_modify_user(&account, &cal.user_id, &ctx).await?;
 

--- a/crates/api/src/event/create_event.rs
+++ b/crates/api/src/event/create_event.rs
@@ -8,6 +8,7 @@ use axum_valid::Valid;
 use chrono::{DateTime, TimeDelta, Utc};
 use nittei_api_structs::create_event::*;
 use nittei_domain::{
+    Account,
     CalendarEvent,
     CalendarEventReminder,
     CalendarEventStatus,
@@ -23,7 +24,7 @@ use crate::{
     error::NitteiError,
     event::subscribers::CreateSyncedEventsOnEventCreated,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_admin_route, protect_route},
+        auth::{Permission, account_can_modify_user, protect_route},
         usecase::{PermissionBoundary, Subscriber, UseCase, execute, execute_with_policy},
     },
 };
@@ -47,12 +48,11 @@ use crate::{
     )
 )]
 pub async fn create_event_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<CreateEventRequestBody>>,
 ) -> Result<(StatusCode, Json<APIResponse>), NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let user = account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 
     let mut body = body.0;

--- a/crates/api/src/event/delete_event.rs
+++ b/crates/api/src/event/delete_event.rs
@@ -1,6 +1,6 @@
 use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use nittei_api_structs::delete_event::*;
-use nittei_domain::{CalendarEvent, ID, IntegrationProvider, User};
+use nittei_domain::{Account, CalendarEvent, ID, IntegrationProvider, User};
 use nittei_infra::{
     NitteiContext,
     google_calendar::GoogleCalendarProvider,
@@ -12,13 +12,7 @@ use tracing::error;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{
-            Permission,
-            account_can_modify_event,
-            account_can_modify_user,
-            protect_admin_route,
-            protect_route,
-        },
+        auth::{Permission, account_can_modify_event, account_can_modify_user, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -39,11 +33,10 @@ use crate::{
     )
 )]
 pub async fn delete_event_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
     let user = account_can_modify_user(&account, &e.user_id, &ctx).await?;
 

--- a/crates/api/src/event/delete_many_events.rs
+++ b/crates/api/src/event/delete_many_events.rs
@@ -1,18 +1,14 @@
-use axum::{
-    Extension,
-    Json,
-    http::{HeaderMap, StatusCode},
-};
+use axum::{Extension, Json, http::StatusCode};
 use axum_valid::Valid;
 use futures::future::{self, try_join};
 use nittei_api_structs::delete_many_events::DeleteManyEventsRequestBody;
-use nittei_domain::ID;
+use nittei_domain::{Account, ID};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, protect_admin_route},
+        auth::Permission,
         usecase::{PermissionBoundary, UseCase, execute},
     },
 };
@@ -33,12 +29,10 @@ use crate::{
     )
 )]
 pub async fn delete_many_events_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<DeleteManyEventsRequestBody>>,
 ) -> Result<StatusCode, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = DeleteManyEventsUseCase {
         account_uid: account.id,
         event_ids: body.event_ids.clone(),

--- a/crates/api/src/event/get_event.rs
+++ b/crates/api/src/event/get_event.rs
@@ -1,12 +1,12 @@
 use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use nittei_api_structs::get_event::*;
-use nittei_domain::{CalendarEvent, ID};
+use nittei_domain::{Account, CalendarEvent, ID};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_event, protect_admin_route, protect_route},
+        auth::{account_can_modify_event, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -27,11 +27,10 @@ use crate::{
     )
 )]
 pub async fn get_event_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
 
     let usecase = GetEventUseCase {

--- a/crates/api/src/event/get_event_by_external_id.rs
+++ b/crates/api/src/event/get_event_by_external_id.rs
@@ -1,14 +1,11 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::{dtos::CalendarEventDTO, get_event_by_external_id::*};
-use nittei_domain::ID;
+use nittei_domain::{Account, ID};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -27,12 +24,10 @@ use crate::{
     )
 )]
 pub async fn get_event_by_external_id_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetEventsByExternalIdAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = GetEventByExternalIdUseCase {
         account_id: account.id,
         external_id: path_params.external_id.clone(),

--- a/crates/api/src/event/get_event_instances.rs
+++ b/crates/api/src/event/get_event_instances.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use nittei_api_structs::get_event_instances::*;
 use nittei_domain::{
+    Account,
     CalendarEvent,
     EventInstance,
     ID,
@@ -20,7 +21,7 @@ use tracing::error;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_event, protect_admin_route, protect_route},
+        auth::{account_can_modify_event, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -41,12 +42,11 @@ use crate::{
     )
 )]
 pub async fn get_event_instances_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     query_params: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetEventInstancesAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
 
     let usecase = GetEventInstancesUseCase {

--- a/crates/api/src/event/get_events_by_calendars.rs
+++ b/crates/api/src/event/get_events_by_calendars.rs
@@ -2,11 +2,11 @@ use axum::{
     Extension,
     Json,
     extract::{Path, Query},
-    http::HeaderMap,
 };
 use chrono::{DateTime, Utc};
 use nittei_api_structs::get_events_by_calendars::*;
 use nittei_domain::{
+    Account,
     EventWithInstances,
     ID,
     TimeSpan,
@@ -19,10 +19,7 @@ use tracing::error;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -44,13 +41,11 @@ use crate::{
     )
 )]
 pub async fn get_events_by_calendars_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     query: Query<GetEventsByCalendarsQueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetEventsByCalendarsAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let calendar_ids = match &query.calendar_ids {
         Some(ids) => ids.clone(),
         None => vec![],

--- a/crates/api/src/event/get_events_by_meta.rs
+++ b/crates/api/src/event/get_events_by_meta.rs
@@ -1,9 +1,9 @@
-use axum::{Extension, Json, extract::Query, http::HeaderMap};
+use axum::{Extension, Json, extract::Query};
 use nittei_api_structs::get_events_by_meta::*;
-use nittei_domain::Metadata;
+use nittei_domain::{Account, Metadata};
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_admin_route};
+use crate::error::NitteiError;
 
 #[utoipa::path(
     get,
@@ -24,12 +24,10 @@ use crate::{error::NitteiError, shared::auth::protect_admin_route};
     )
 )]
 pub async fn get_events_by_meta_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     query_params: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetEventsByMetaAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let query = MetadataFindQuery {
         account_id: account.id,
         metadata: Metadata::new_kv(query_params.0.key, query_params.0.value),

--- a/crates/api/src/event/get_events_for_users_in_time_range.rs
+++ b/crates/api/src/event/get_events_for_users_in_time_range.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
-use axum::{Extension, Json, http::HeaderMap};
+use axum::{Extension, Json};
 use axum_valid::Valid;
 use chrono::{DateTime, Utc};
 use nittei_api_structs::get_events_for_users_in_time_range::*;
 use nittei_domain::{
+    Account,
     EventWithInstances,
     ID,
     TimeSpan,
@@ -17,10 +18,7 @@ use tracing::error;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -39,12 +37,10 @@ use crate::{
 ///
 /// Optionally, it can generate the instances of the recurring events
 pub async fn get_events_for_users_in_time_range_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<GetEventsForUsersInTimeSpanBody>>,
 ) -> Result<Json<GetEventsForUsersInTimeSpanAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = GetEventsForUsersInTimeRangeUseCase {
         account_id: account.id,
         user_ids: body.user_ids.clone(),

--- a/crates/api/src/event/mod.rs
+++ b/crates/api/src/event/mod.rs
@@ -24,58 +24,47 @@ use search_events::search_events_controller;
 use update_event::{update_event_admin_controller, update_event_controller};
 use utoipa_axum::router::OpenApiRouter;
 
+use crate::shared::auth;
+
 // Configure the routes for the event module
 pub fn configure_routes() -> OpenApiRouter {
-    OpenApiRouter::new()
-        // Create an event
-        .route("/events", post(create_event_controller))
+    let admin_router = OpenApiRouter::new()
         // Create an event for a user (admin route)
         .route(
             "/user/{user_id}/events",
             post(create_event_admin_controller),
+        )
+        // Search events
+        // /!\ This is a POST route
+        .route("/events/search", post(search_events_controller))
+        // Get events by metadata
+        .route("/events/meta", get(get_events_by_meta_controller))
+        // Get events of multiple users during a time range
+        .route(
+            "/events/timespan",
+            post(get_events_for_users_in_time_range::get_events_for_users_in_time_range_controller),
         )
         // Get events by calendars
         .route(
             "/user/{user_id}/events",
             get(get_events_by_calendars::get_events_by_calendars_controller),
         )
-        // Get events of multiple users during a time range
-        .route(
-            "/events/timespan",
-            post(get_events_for_users_in_time_range::get_events_for_users_in_time_range_controller),
-        )
-        // Get events by metadata
-        .route("/events/meta", get(get_events_by_meta_controller))
-        // Search events
-        // /!\ This is a POST route
-        .route("/events/search", post(search_events_controller))
         // Get a specific event by external id
         .route(
             "/user/events/external_id/{external_id}",
             get(get_event_by_external_id::get_event_by_external_id_admin_controller),
         )
-        // Get a specific event by uid
-        .route("/events/{event_id}", get(get_event_controller))
         // Get a specific event by uid (admin route)
         .route("/user/events/{event_id}", get(get_event_admin_controller))
-        // Delete an event by uid
-        .route("/events/{event_id}", delete(delete_event_controller))
-        // Delete an event by uid (admin route)
-        .route(
-            "/user/events/{event_id}",
-            delete(delete_event_admin_controller),
-        )
-        // Update an event by uid
-        .route("/events/{event_id}", put(update_event_controller))
         // Update an event by uid (admin route)
         .route(
             "/user/events/{event_id}",
             put(update_event_admin_controller),
         )
-        // Get event instances
+        // Delete an event by uid (admin route)
         .route(
-            "/events/{event_id}/instances",
-            get(get_event_instances_controller),
+            "/user/events/{event_id}",
+            delete(delete_event_admin_controller),
         )
         // Get event instances (admin route)
         .route(
@@ -87,4 +76,22 @@ pub fn configure_routes() -> OpenApiRouter {
             "/user/events/delete_many",
             post(delete_many_events_admin_controller),
         )
+        .route_layer(axum::middleware::from_fn(auth::protect_admin_route));
+
+    let user_router = OpenApiRouter::new()
+        // Create an event
+        .route("/events", post(create_event_controller))
+        // Get a specific event by uid
+        .route("/events/{event_id}", get(get_event_controller))
+        // Update an event by uid
+        .route("/events/{event_id}", put(update_event_controller))
+        // Delete an event by uid
+        .route("/events/{event_id}", delete(delete_event_controller))
+        // Get event instances
+        .route(
+            "/events/{event_id}/instances",
+            get(get_event_instances_controller),
+        );
+
+    OpenApiRouter::new().merge(admin_router).merge(user_router)
 }

--- a/crates/api/src/event/search_events.rs
+++ b/crates/api/src/event/search_events.rs
@@ -1,16 +1,21 @@
-use axum::{Extension, Json, http::HeaderMap};
+use axum::{Extension, Json};
 use axum_valid::Valid;
 use nittei_api_structs::{dtos::CalendarEventDTO, search_events::*};
-use nittei_domain::{CalendarEventSort, DateTimeQuery, ID, IDQuery, RecurrenceQuery, StringQuery};
+use nittei_domain::{
+    Account,
+    CalendarEventSort,
+    DateTimeQuery,
+    ID,
+    IDQuery,
+    RecurrenceQuery,
+    StringQuery,
+};
 use nittei_infra::{NitteiContext, SearchEventsForUserParams, SearchEventsParams};
 use nittei_utils::config::APP_CONFIG;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -29,12 +34,10 @@ use crate::{
     )
 )]
 pub async fn search_events_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<SearchEventsRequestBody>>,
 ) -> Result<Json<SearchEventsAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let mut body = body.0;
     let usecase = SearchEventsUseCase {
         account_id: account.id,

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, TimeDelta, Utc};
 use event::subscribers::SyncRemindersOnEventUpdated;
 use nittei_api_structs::update_event::*;
 use nittei_domain::{
+    Account,
     CalendarEvent,
     CalendarEventReminder,
     CalendarEventStatus,
@@ -18,13 +19,7 @@ use crate::{
     error::NitteiError,
     event::{self, subscribers::UpdateSyncedEventsOnEventUpdated},
     shared::{
-        auth::{
-            Permission,
-            account_can_modify_event,
-            account_can_modify_user,
-            protect_admin_route,
-            protect_route,
-        },
+        auth::{Permission, account_can_modify_event, account_can_modify_user, protect_route},
         usecase::{PermissionBoundary, Subscriber, UseCase, execute, execute_with_policy},
     },
 };
@@ -48,12 +43,11 @@ use crate::{
     )
 )]
 pub async fn update_event_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<UpdateEventRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
     let user = account_can_modify_user(&account, &e.user_id, &ctx).await?;
 

--- a/crates/api/src/schedule/create_schedule.rs
+++ b/crates/api/src/schedule/create_schedule.rs
@@ -6,24 +6,23 @@ use axum::{
 };
 use chrono_tz::Tz;
 use nittei_api_structs::create_schedule::*;
-use nittei_domain::{ID, Schedule, ScheduleRule};
+use nittei_domain::{Account, ID, Schedule, ScheduleRule};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_user, protect_admin_route, protect_route},
+        auth::{Permission, account_can_modify_user, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
 
 pub async fn create_schedule_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body_params: Json<RequestBody>,
 ) -> Result<(StatusCode, Json<APIResponse>), NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let user = account_can_modify_user(&account, &path_params.user_id, &ctx).await?;
 
     let mut body_params = body_params.0;

--- a/crates/api/src/schedule/delete_schedule.rs
+++ b/crates/api/src/schedule/delete_schedule.rs
@@ -1,22 +1,21 @@
 use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use nittei_api_structs::delete_schedule::*;
-use nittei_domain::{ID, Schedule};
+use nittei_domain::{Account, ID, Schedule};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_schedule, protect_admin_route, protect_route},
+        auth::{Permission, account_can_modify_schedule, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
 
 pub async fn delete_schedule_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let schedule = account_can_modify_schedule(&account, &path.schedule_id, &ctx).await?;
 
     let usecase = DeleteScheduleUseCase {

--- a/crates/api/src/schedule/get_schedule.rs
+++ b/crates/api/src/schedule/get_schedule.rs
@@ -1,22 +1,21 @@
 use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use nittei_api_structs::get_schedule::*;
-use nittei_domain::{ID, Schedule};
+use nittei_domain::{Account, ID, Schedule};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_schedule, protect_admin_route, protect_route},
+        auth::{account_can_modify_schedule, protect_route},
         usecase::{UseCase, execute},
     },
 };
 
 pub async fn get_schedule_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let schedule = account_can_modify_schedule(&account, &path.schedule_id, &ctx).await?;
 
     let usecase = GetScheduleUseCase {

--- a/crates/api/src/schedule/get_schedules_by_meta.rs
+++ b/crates/api/src/schedule/get_schedules_by_meta.rs
@@ -1,17 +1,15 @@
-use axum::{Extension, Json, extract::Query, http::HeaderMap};
+use axum::{Extension, Json, extract::Query};
 use nittei_api_structs::get_schedules_by_meta::*;
-use nittei_domain::Metadata;
+use nittei_domain::{Account, Metadata};
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_admin_route};
+use crate::error::NitteiError;
 
 pub async fn get_schedules_by_meta_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     query_params: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let query = MetadataFindQuery {
         account_id: account.id,
         metadata: Metadata::new_kv(query_params.0.key, query_params.0.value),

--- a/crates/api/src/schedule/update_schedule.rs
+++ b/crates/api/src/schedule/update_schedule.rs
@@ -1,24 +1,23 @@
 use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use chrono_tz::Tz;
 use nittei_api_structs::update_schedule::*;
-use nittei_domain::{ID, Schedule, ScheduleRule};
+use nittei_domain::{Account, ID, Schedule, ScheduleRule};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, account_can_modify_schedule, protect_admin_route, protect_route},
+        auth::{Permission, account_can_modify_schedule, protect_route},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
 
 pub async fn update_schedule_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Json<RequestBody>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let schedule = account_can_modify_schedule(&account, &path.schedule_id, &ctx).await?;
 
     let mut body = body.0;

--- a/crates/api/src/service/add_busy_calendar.rs
+++ b/crates/api/src/service/add_busy_calendar.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::add_busy_calendar::*;
 use nittei_domain::{
     Account,
@@ -17,20 +17,15 @@ use nittei_infra::{
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn add_busy_calendar_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Json<RequestBody>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let body = body.0;
     let usecase = AddBusyCalendarUseCase {
         account,

--- a/crates/api/src/service/add_user_to_service.rs
+++ b/crates/api/src/service/add_user_to_service.rs
@@ -1,24 +1,19 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::add_user_to_service::*;
 use nittei_domain::{Account, ID, ServiceResource, TimePlan};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn add_user_to_service_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     mut body: Json<RequestBody>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = AddUserToServiceUseCase {
         account,
         service_id: std::mem::take(&mut path.service_id),

--- a/crates/api/src/service/create_service.rs
+++ b/crates/api/src/service/create_service.rs
@@ -1,27 +1,18 @@
-use axum::{
-    Extension,
-    Json,
-    http::{HeaderMap, StatusCode},
-};
+use axum::{Extension, Json, http::StatusCode};
 use nittei_api_structs::create_service::*;
 use nittei_domain::{Account, Service, ServiceMultiPersonOptions};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn create_service_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     body: Json<RequestBody>,
 ) -> Result<(StatusCode, Json<APIResponse>), NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let mut body = body.0;
     let usecase = CreateServiceUseCase {
         account,

--- a/crates/api/src/service/create_service_event_intend.rs
+++ b/crates/api/src/service/create_service_event_intend.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use chrono::{DateTime, Duration, TimeDelta, Utc};
 use get_service_bookingslots::GetServiceBookingSlotsUseCase;
 use nittei_api_structs::create_service_event_intend::*;
@@ -19,20 +19,14 @@ use tracing::warn;
 use super::get_service_bookingslots;
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn create_service_event_intend_controller(
-    headers: HeaderMap,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Json<RequestBody>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    protect_admin_route(&headers, &ctx).await?;
-
     let mut body = body.0;
     let usecase = CreateServiceEventIntendUseCase {
         service_id: std::mem::take(&mut path.service_id),

--- a/crates/api/src/service/delete_service.rs
+++ b/crates/api/src/service/delete_service.rs
@@ -1,23 +1,18 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::delete_service::*;
 use nittei_domain::{Account, ID, Service};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn delete_service_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = DeleteServiceUseCase {
         account,
         service_id: path_params.service_id.clone(),

--- a/crates/api/src/service/get_service.rs
+++ b/crates/api/src/service/get_service.rs
@@ -1,23 +1,18 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::get_service::*;
 use nittei_domain::{Account, ID, ServiceWithUsers};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn get_service_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = GetServiceUseCase {
         account,
         service_id: path_params.service_id.clone(),

--- a/crates/api/src/service/get_service_bookingslots.rs
+++ b/crates/api/src/service/get_service_bookingslots.rs
@@ -2,7 +2,6 @@ use axum::{
     Extension,
     Json,
     extract::{Path, Query},
-    http::HeaderMap,
 };
 use chrono::TimeDelta;
 use futures::future::join_all;
@@ -47,7 +46,6 @@ use crate::{
 };
 
 pub async fn get_service_bookingslots_controller(
-    _headers: HeaderMap,
     query_params: Query<QueryParams>,
     mut path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,

--- a/crates/api/src/service/get_services_by_meta.rs
+++ b/crates/api/src/service/get_services_by_meta.rs
@@ -1,17 +1,15 @@
-use axum::{Extension, Json, extract::Query, http::HeaderMap};
+use axum::{Extension, Json, extract::Query};
 use nittei_api_structs::get_services_by_meta::*;
-use nittei_domain::Metadata;
+use nittei_domain::{Account, Metadata};
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_admin_route};
+use crate::error::NitteiError;
 
 pub async fn get_services_by_meta_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     query_params: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let query = MetadataFindQuery {
         account_id: account.id,
         metadata: Metadata::new_kv(query_params.0.key, query_params.0.value),

--- a/crates/api/src/service/mod.rs
+++ b/crates/api/src/service/mod.rs
@@ -28,6 +28,8 @@ use update_service::update_service_controller;
 use update_service_user::update_service_user_controller;
 use utoipa_axum::router::OpenApiRouter;
 
+use crate::shared::auth;
+
 pub fn configure_routes() -> OpenApiRouter {
     OpenApiRouter::new()
         .route("/service", post(create_service_controller))
@@ -67,4 +69,5 @@ pub fn configure_routes() -> OpenApiRouter {
             "/service/{service_id}/booking-intend",
             delete(remove_service_event_intend_controller),
         )
+        .route_layer(axum::middleware::from_fn(auth::protect_admin_route))
 }

--- a/crates/api/src/service/remove_busy_calendar.rs
+++ b/crates/api/src/service/remove_busy_calendar.rs
@@ -1,24 +1,19 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::remove_busy_calendar::*;
 use nittei_domain::{Account, BusyCalendarProvider, ID, IntegrationProvider};
 use nittei_infra::{BusyCalendarIdentifier, ExternalBusyCalendarIdentifier, NitteiContext};
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn remove_busy_calendar_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Json<RequestBody>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let body = body.0;
 
     let usecase = RemoveBusyCalendarUseCase {

--- a/crates/api/src/service/remove_service_event_intend.rs
+++ b/crates/api/src/service/remove_service_event_intend.rs
@@ -2,7 +2,6 @@ use axum::{
     Extension,
     Json,
     extract::{Path, Query},
-    http::HeaderMap,
 };
 use chrono::{DateTime, Utc};
 use nittei_api_structs::remove_service_event_intend::*;
@@ -11,20 +10,15 @@ use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn remove_service_event_intend_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     query_params: Query<QueryParams>,
     mut path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let query = query_params.0;
     let usecase = RemoveServiceEventIntendUseCase {
         account,

--- a/crates/api/src/service/remove_user_from_service.rs
+++ b/crates/api/src/service/remove_user_from_service.rs
@@ -1,23 +1,18 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::remove_user_from_service::*;
 use nittei_domain::{Account, ID};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn remove_user_from_service_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = RemoveUserFromServiceUseCase {
         account,
         service_id: std::mem::take(&mut path.service_id),

--- a/crates/api/src/service/update_service.rs
+++ b/crates/api/src/service/update_service.rs
@@ -1,24 +1,19 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::update_service::*;
-use nittei_domain::{ID, Service, ServiceMultiPersonOptions};
+use nittei_domain::{Account, ID, Service, ServiceMultiPersonOptions};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn update_service_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Json<RequestBody>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let mut body = body.0;
     let usecase = UpdateServiceUseCase {
         account_id: account.id,

--- a/crates/api/src/service/update_service_user.rs
+++ b/crates/api/src/service/update_service_user.rs
@@ -1,4 +1,4 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::update_service_user::*;
 use nittei_domain::{Account, ID, ServiceResource, TimePlan};
 use nittei_infra::NitteiContext;
@@ -10,20 +10,15 @@ use super::add_user_to_service::{
 };
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 pub async fn update_service_user_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     mut body: Json<RequestBody>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = UpdateServiceUserUseCase {
         account,
         service_id: std::mem::take(&mut path.service_id),

--- a/crates/api/src/shared/auth/route_guards.rs
+++ b/crates/api/src/shared/auth/route_guards.rs
@@ -156,6 +156,26 @@ pub async fn protect_admin_route(
     request: Request,
     next: Next,
 ) -> Result<Response, NitteiError> {
+    let account = protect_admin_route_inner(&headers, &ctx).await?;
+
+    // Inject the account into the request extensions
+    let mut request = request;
+    request.extensions_mut().insert(account);
+
+    // Run the next middleware or the final handler
+    Ok(next.run(request).await)
+}
+
+/// Inner function for protecting admin routes
+///
+/// This function will check if the request has a valid `x-api-key` header
+/// and if the token is the one stored in DB for the `Account`
+///
+/// It's separated from the outer function to make it easier to test and to re-use the logic
+async fn protect_admin_route_inner(
+    headers: &HeaderMap,
+    ctx: &NitteiContext,
+) -> Result<Account, NitteiError> {
     let api_key = headers
         .get("x-api-key")
         .and_then(|v| v.to_str().ok())
@@ -169,12 +189,7 @@ pub async fn protect_admin_route(
         .map_err(|_| NitteiError::InternalError)?
         .ok_or_else(|| NitteiError::Unauthorized("Invalid api-key".into()))?;
 
-    // Inject the account into the request extensions
-    let mut request = request;
-    request.extensions_mut().insert(account);
-
-    // Run the next middleware or the final handler
-    Ok(next.run(request).await)
+    Ok(account)
 }
 
 /// Only checks which account the request is connected to.
@@ -201,22 +216,7 @@ pub async fn protect_public_account_route(
                 })
         }
         // No nittei-account header, then check if this is an admin client
-        None => {
-            let api_key = headers
-                .get("x-api-key")
-                .and_then(|v| v.to_str().ok())
-                .ok_or_else(|| NitteiError::Unauthorized("Missing x-api-key header".into()))?;
-
-            let account = ctx
-                .repos
-                .accounts
-                .find_by_apikey(api_key)
-                .await
-                .map_err(|_| NitteiError::InternalError)?
-                .ok_or_else(|| NitteiError::Unauthorized("Invalid api-key".into()))?;
-
-            Ok(account)
-        }
+        None => protect_admin_route_inner(headers, ctx).await,
     }
 }
 

--- a/crates/api/src/shared/auth/route_guards.rs
+++ b/crates/api/src/shared/auth/route_guards.rs
@@ -145,7 +145,10 @@ pub async fn protect_route(
     }
 }
 
-/// Middleware to require admin authentication
+/// Middleware for protecting admin routes
+///
+/// This function will check if the request has a valid `x-api-key` header
+/// and if the token is the one stored in DB for the `Account`
 #[instrument(name = "auth::protect_admin_route", skip_all)]
 pub async fn protect_admin_route(
     Extension(ctx): Extension<NitteiContext>,

--- a/crates/api/src/shared/auth/route_guards.rs
+++ b/crates/api/src/shared/auth/route_guards.rs
@@ -1,4 +1,4 @@
-use axum::http::HeaderMap;
+use axum::{Extension, extract::Request, http::HeaderMap, middleware::Next, response::Response};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use nittei_domain::{Account, Calendar, CalendarEvent, ID, Schedule, User};
 use nittei_infra::NitteiContext;
@@ -145,39 +145,33 @@ pub async fn protect_route(
     }
 }
 
-/// Protects admin routes
-///
-/// This function will check if the request has a valid `x-api-key` header
-/// and if the token is the one stored in DB for the `Account`
+/// Middleware to require admin authentication
 #[instrument(name = "auth::protect_admin_route", skip_all)]
 pub async fn protect_admin_route(
-    headers: &HeaderMap,
-    ctx: &NitteiContext,
-) -> Result<Account, NitteiError> {
-    let api_key = match headers.get("x-api-key") {
-        Some(api_key) => match api_key.to_str() {
-            Ok(api_key) => api_key,
-            Err(_) => {
-                return Err(NitteiError::Unauthorized(
-                    "Malformed api key provided".to_string(),
-                ));
-            }
-        },
-        None => {
-            return Err(NitteiError::Unauthorized(
-                "Unable to find api-key in x-api-key header".to_string(),
-            ));
-        }
-    };
+    Extension(ctx): Extension<NitteiContext>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Result<Response, NitteiError> {
+    let api_key = headers
+        .get("x-api-key")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| NitteiError::Unauthorized("Missing x-api-key header".into()))?;
 
-    ctx.repos
+    let account = ctx
+        .repos
         .accounts
         .find_by_apikey(api_key)
         .await
         .map_err(|_| NitteiError::InternalError)?
-        .ok_or_else(|| {
-            NitteiError::Unauthorized("Invalid api-key provided in x-api-key header".to_string())
-        })
+        .ok_or_else(|| NitteiError::Unauthorized("Invalid api-key".into()))?;
+
+    // Inject the account into the request extensions
+    let mut request = request;
+    request.extensions_mut().insert(account);
+
+    // Run the next middleware or the final handler
+    Ok(next.run(request).await)
 }
 
 /// Only checks which account the request is connected to.
@@ -204,7 +198,22 @@ pub async fn protect_public_account_route(
                 })
         }
         // No nittei-account header, then check if this is an admin client
-        None => protect_admin_route(headers, ctx).await,
+        None => {
+            let api_key = headers
+                .get("x-api-key")
+                .and_then(|v| v.to_str().ok())
+                .ok_or_else(|| NitteiError::Unauthorized("Missing x-api-key header".into()))?;
+
+            let account = ctx
+                .repos
+                .accounts
+                .find_by_apikey(api_key)
+                .await
+                .map_err(|_| NitteiError::InternalError)?
+                .ok_or_else(|| NitteiError::Unauthorized("Invalid api-key".into()))?;
+
+            Ok(account)
+        }
     }
 }
 

--- a/crates/api/src/user/create_user.rs
+++ b/crates/api/src/user/create_user.rs
@@ -1,19 +1,12 @@
-use axum::{
-    Extension,
-    Json,
-    http::{HeaderMap, StatusCode},
-};
+use axum::{Extension, Json, http::StatusCode};
 use futures::{FutureExt, try_join};
 use nittei_api_structs::create_user::*;
-use nittei_domain::{ID, User};
+use nittei_domain::{Account, ID, User};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -29,12 +22,10 @@ use crate::{
     )
 )]
 pub async fn create_user_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     Extension(ctx): Extension<NitteiContext>,
     mut body: Json<CreateUserRequestBody>,
 ) -> Result<(StatusCode, Json<APIResponse>), NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = CreateUserUseCase {
         account_id: account.id,
         metadata: body.0.metadata.take(),

--- a/crates/api/src/user/delete_user.rs
+++ b/crates/api/src/user/delete_user.rs
@@ -1,14 +1,11 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::delete_user::*;
 use nittei_domain::{Account, ID, User};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -27,12 +24,10 @@ use crate::{
     )
 )]
 pub async fn delete_user_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = DeleteUserUseCase {
         account,
         user_id: path_params.user_id.clone(),

--- a/crates/api/src/user/get_user.rs
+++ b/crates/api/src/user/get_user.rs
@@ -1,14 +1,11 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::get_user::*;
 use nittei_domain::{Account, ID, User};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -27,12 +24,10 @@ use crate::{
     )
 )]
 pub async fn get_user_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = GetUserUseCase {
         account,
         user_id: path_params.user_id.clone(),

--- a/crates/api/src/user/get_user_by_external_id.rs
+++ b/crates/api/src/user/get_user_by_external_id.rs
@@ -1,14 +1,11 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::get_user_by_external_id::*;
 use nittei_domain::{Account, User};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -27,12 +24,10 @@ use crate::{
     )
 )]
 pub async fn get_user_by_external_id_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path_params: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = GetUserByExternalIdUseCase {
         account,
         external_id: path_params.external_id.clone(),

--- a/crates/api/src/user/get_users_by_meta.rs
+++ b/crates/api/src/user/get_users_by_meta.rs
@@ -1,9 +1,9 @@
-use axum::{Extension, Json, extract::Query, http::HeaderMap};
+use axum::{Extension, Json, extract::Query};
 use nittei_api_structs::get_users_by_meta::*;
-use nittei_domain::Metadata;
+use nittei_domain::{Account, Metadata};
 use nittei_infra::{MetadataFindQuery, NitteiContext};
 
-use crate::{error::NitteiError, shared::auth::protect_admin_route};
+use crate::error::NitteiError;
 
 #[utoipa::path(
     get,
@@ -24,12 +24,10 @@ use crate::{error::NitteiError, shared::auth::protect_admin_route};
     )
 )]
 pub async fn get_users_by_meta_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     query_params: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetUsersByMetaAPIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let query = MetadataFindQuery {
         account_id: account.id,
         metadata: Metadata::new_kv(query_params.0.key, query_params.0.value),

--- a/crates/api/src/user/mod.rs
+++ b/crates/api/src/user/mod.rs
@@ -45,8 +45,6 @@ pub fn configure_routes() -> OpenApiRouter {
         .route("/user/{user_id}", put(update_user_controller))
         // Delete a specific user by id
         .route("/user/{user_id}", delete(delete_user_controller))
-        // Get freebusy for a specific user
-        .route("/user/{user_id}/freebusy", get(get_freebusy_controller))
         .route(
             "/user/{user_id}/oauth",
             post(oauth_integration_admin_controller),
@@ -63,6 +61,8 @@ pub fn configure_routes() -> OpenApiRouter {
         // Get freebusy for multiple users
         // This is a POST route !
         .route("/user/freebusy", post(get_multiple_freebusy_controller))
+        // Get freebusy for a specific user
+        .route("/user/{user_id}/freebusy", get(get_freebusy_controller))
         // Oauth
         .route("/me/oauth", post(oauth_integration_controller))
         .route(

--- a/crates/api/src/user/mod.rs
+++ b/crates/api/src/user/mod.rs
@@ -25,37 +25,28 @@ use remove_integration::{remove_integration_admin_controller, remove_integration
 use update_user::update_user_controller;
 use utoipa_axum::router::OpenApiRouter;
 
+use crate::shared::auth;
+
 // Configure the routes for the user module
 pub fn configure_routes() -> OpenApiRouter {
-    OpenApiRouter::new()
+    let admin_router = OpenApiRouter::new()
         // Create a new user
         .route("/user", post(create_user_controller))
-        // Get the current user
-        .route("/me", get(get_me_controller))
         // Get users by metadata
         .route("/user/meta", get(get_users_by_meta_controller))
+        // Get a specific user by id
+        .route("/user/{user_id}", get(get_user_controller))
         // Get user by external_id
         .route(
             "/user/external_id/{external_id}",
             get(get_user_by_external_id_controller),
         )
-        // Get freebusy for multiple users
-        // This is a POST route !
-        .route("/user/freebusy", post(get_multiple_freebusy_controller))
-        // Get a specific user by id
-        .route("/user/{user_id}", get(get_user_controller))
         // Update a specific user by id
         .route("/user/{user_id}", put(update_user_controller))
         // Delete a specific user by id
         .route("/user/{user_id}", delete(delete_user_controller))
         // Get freebusy for a specific user
         .route("/user/{user_id}/freebusy", get(get_freebusy_controller))
-        // Oauth
-        .route("/me/oauth", post(oauth_integration_controller))
-        .route(
-            "/me/oauth/{provider}",
-            delete(remove_integration_controller),
-        )
         .route(
             "/user/{user_id}/oauth",
             post(oauth_integration_admin_controller),
@@ -64,4 +55,20 @@ pub fn configure_routes() -> OpenApiRouter {
             "/user/{user_id}/oauth/{provider}",
             delete(remove_integration_admin_controller),
         )
+        .route_layer(axum::middleware::from_fn(auth::protect_admin_route));
+
+    let user_router = OpenApiRouter::new()
+        // Get the current user
+        .route("/me", get(get_me_controller))
+        // Get freebusy for multiple users
+        // This is a POST route !
+        .route("/user/freebusy", post(get_multiple_freebusy_controller))
+        // Oauth
+        .route("/me/oauth", post(oauth_integration_controller))
+        .route(
+            "/me/oauth/{provider}",
+            delete(remove_integration_controller),
+        );
+
+    OpenApiRouter::new().merge(admin_router).merge(user_router)
 }

--- a/crates/api/src/user/oauth_integration.rs
+++ b/crates/api/src/user/oauth_integration.rs
@@ -2,13 +2,13 @@ use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use axum_valid::Valid;
 use chrono::Utc;
 use nittei_api_structs::oauth_integration::*;
-use nittei_domain::{ID, IntegrationProvider, User, UserIntegration};
+use nittei_domain::{Account, ID, IntegrationProvider, User, UserIntegration};
 use nittei_infra::{CodeTokenRequest, NitteiContext, ProviderOAuth};
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_user, protect_admin_route, protect_route},
+        auth::{account_can_modify_user, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -32,12 +32,11 @@ use crate::{
     )
 )]
 pub async fn oauth_integration_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<OAuthIntegrationRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let user = account_can_modify_user(&account, &path.user_id, &ctx).await?;
 
     let usecase = OAuthIntegrationUseCase {

--- a/crates/api/src/user/remove_integration.rs
+++ b/crates/api/src/user/remove_integration.rs
@@ -1,12 +1,12 @@
 use axum::{Extension, Json, extract::Path, http::HeaderMap};
 use nittei_api_structs::remove_integration::*;
-use nittei_domain::{ID, IntegrationProvider, User};
+use nittei_domain::{Account, ID, IntegrationProvider, User};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{account_can_modify_user, protect_admin_route, protect_route},
+        auth::{account_can_modify_user, protect_route},
         usecase::{UseCase, execute},
     },
 };
@@ -28,11 +28,10 @@ use crate::{
     )
 )]
 pub async fn remove_integration_admin_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
     let user = account_can_modify_user(&account, &path.user_id, &ctx).await?;
 
     let usecase = OAuthIntegrationUseCase {

--- a/crates/api/src/user/update_user.rs
+++ b/crates/api/src/user/update_user.rs
@@ -1,14 +1,11 @@
-use axum::{Extension, Json, extract::Path, http::HeaderMap};
+use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::update_user::*;
-use nittei_domain::{ID, User};
+use nittei_domain::{Account, ID, User};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
-    shared::{
-        auth::protect_admin_route,
-        usecase::{UseCase, execute},
-    },
+    shared::usecase::{UseCase, execute},
 };
 
 #[utoipa::path(
@@ -30,13 +27,11 @@ use crate::{
     )
 )]
 pub async fn update_user_controller(
-    headers: HeaderMap,
+    Extension(account): Extension<Account>,
     mut path: Path<PathParams>,
     Extension(ctx): Extension<NitteiContext>,
     mut body: Json<UpdateUserRequestBody>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let account = protect_admin_route(&headers, &ctx).await?;
-
     let usecase = UpdateUserUseCase {
         account_id: account.id,
         external_id: body.0.external_id.take(),


### PR DESCRIPTION
### Changed
- Adapted code so that instead of explicitly calling a function in each handler, we use a middleware for protecting **admin** routes