### PR TITLE
fix(telemetry): set sampler for otel too

### DIFF
--- a/bins/nittei/src/telemetry.rs
+++ b/bins/nittei/src/telemetry.rs
@@ -171,6 +171,7 @@ fn get_tracer_otlp(
                 .build(),
         )
         .with_batch_exporter(otlp_exporter)
+        .with_sampler(get_sampler())
         .build())
 }
 


### PR DESCRIPTION
### Changed
- Fix sampler not configured for Otel tracing (it's correctly set for Datadog tracing) 