### PR TITLE
fix: convert http logs to ms

### DIFF
--- a/crates/api/src/http_logger.rs
+++ b/crates/api/src/http_logger.rs
@@ -131,7 +131,7 @@ impl<B> OnResponse<B> for NitteiTracingOnResponse {
         tracing::span::Span::current().record("level", tracing::field::display(level));
 
         let message = format!(
-            "{} {} {} {}ns",
+            "{} {} {} {}ms",
             method,
             uri_string,
             status_code,


### PR DESCRIPTION
### Changed
- [http logger] Convert log messages from `ns` to `ms`