### PR TITLE
fix: add basic debug symbol for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ expect_used = "deny"
 lto = "thin"
 # https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units
 codegen-units = 1
+# Add basic debug information, at the cost of binary size
+# See https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+debug = 1


### PR DESCRIPTION
### Changed
- Add basic debug symbols in the release binary, so that we get line numbers