### PR TITLE
test: skip flaky load test

### DIFF
--- a/clients/javascript/tests/requirements/loadTests.spec.ts
+++ b/clients/javascript/tests/requirements/loadTests.spec.ts
@@ -55,7 +55,8 @@ async function create200Events(
   return events
 }
 
-describe('Load tests', () => {
+// We run it on demand, when we need to load test
+describe.skip('Load tests', () => {
   let client: INitteiClient | undefined
 
   beforeAll(async () => {


### PR DESCRIPTION
### Changed
- Skip testing load test in CI as it's flaky
  - We can always run it manually when needed
  - We are monitoring performance via our internal APM