### PR TITLE
feat(event): avoid refetching - use route guard

### DIFF
--- a/crates/api/src/event/delete_event.rs
+++ b/crates/api/src/event/delete_event.rs
@@ -12,7 +12,7 @@ use tracing::error;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Permission, Policy, account_can_modify_event, account_can_modify_user},
+        auth::{Permission, Policy, account_can_modify_user},
         usecase::{PermissionBoundary, UseCase, execute, execute_with_policy},
     },
 };
@@ -34,15 +34,15 @@ use crate::{
 )]
 pub async fn delete_event_admin_controller(
     Extension(account): Extension<Account>,
-    path_params: Path<PathParams>,
+    Extension(event): Extension<CalendarEvent>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
-    let user = account_can_modify_user(&account, &e.user_id, &ctx).await?;
+    let user = account_can_modify_user(&account, &event.user_id, &ctx).await?;
 
     let usecase = DeleteEventUseCase {
         user,
-        event_id: e.id,
+        event_id: event.id.clone(),
+        prefetched_calendar_event: Some(event),
     };
 
     execute(usecase, &ctx)
@@ -71,6 +71,7 @@ pub async fn delete_event_controller(
     let usecase = DeleteEventUseCase {
         user,
         event_id: path_params.event_id.clone(),
+        prefetched_calendar_event: None,
     };
 
     execute_with_policy(usecase, &policy, &ctx)
@@ -83,6 +84,7 @@ pub async fn delete_event_controller(
 pub struct DeleteEventUseCase {
     pub user: User,
     pub event_id: ID,
+    pub prefetched_calendar_event: Option<CalendarEvent>,
 }
 
 #[derive(Debug)]
@@ -113,10 +115,13 @@ impl UseCase for DeleteEventUseCase {
 
     // TODO: use only one db call
     async fn execute(&mut self, ctx: &NitteiContext) -> Result<Self::Response, Self::Error> {
-        let event = ctx.repos.events.find(&self.event_id).await.map_err(|e| {
-            tracing::error!("[delete_event] Error finding event: {:?}", e);
-            UseCaseError::StorageError
-        })?;
+        let event = match &self.prefetched_calendar_event {
+            Some(event) => Some(event.clone()),
+            None => ctx.repos.events.find(&self.event_id).await.map_err(|e| {
+                tracing::error!("[delete_event] Error finding event: {:?}", e);
+                UseCaseError::StorageError
+            })?,
+        };
         let e = match event {
             Some(e) if e.user_id == self.user.id => e,
             _ => return Err(UseCaseError::NotFound(self.event_id.clone())),

--- a/crates/api/src/event/delete_event.rs
+++ b/crates/api/src/event/delete_event.rs
@@ -80,10 +80,14 @@ pub async fn delete_event_controller(
         .map_err(NitteiError::from)
 }
 
+/// Use case for deleting an event
 #[derive(Debug)]
 pub struct DeleteEventUseCase {
     pub user: User,
     pub event_id: ID,
+
+    /// Event that has been potentially prefetched by the route guard
+    /// Only happens in the admin controller
     pub prefetched_calendar_event: Option<CalendarEvent>,
 }
 

--- a/crates/api/src/event/get_event.rs
+++ b/crates/api/src/event/get_event.rs
@@ -71,10 +71,14 @@ pub async fn get_event_controller(
         .map_err(NitteiError::from)
 }
 
+/// Use case for getting an event
 #[derive(Debug)]
 pub struct GetEventUseCase {
     pub event_id: ID,
     pub user_id: ID,
+
+    /// Event that has been potentially prefetched by the route guard
+    /// Only happens in the admin controller
     pub prefetched_calendar_event: Option<CalendarEvent>,
 }
 

--- a/crates/api/src/event/get_event.rs
+++ b/crates/api/src/event/get_event.rs
@@ -1,12 +1,12 @@
 use axum::{Extension, Json, extract::Path};
 use nittei_api_structs::get_event::*;
-use nittei_domain::{Account, CalendarEvent, ID, User};
+use nittei_domain::{CalendarEvent, ID, User};
 use nittei_infra::NitteiContext;
 
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Policy, account_can_modify_event},
+        auth::Policy,
         usecase::{UseCase, execute},
     },
 };
@@ -27,15 +27,13 @@ use crate::{
     )
 )]
 pub async fn get_event_admin_controller(
-    Extension(account): Extension<Account>,
-    path_params: Path<PathParams>,
+    Extension(event): Extension<CalendarEvent>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
-
     let usecase = GetEventUseCase {
-        user_id: e.user_id,
-        event_id: e.id,
+        user_id: event.user_id.clone(),
+        event_id: event.id.clone(),
+        prefetched_calendar_event: Some(event),
     };
 
     execute(usecase, &ctx)
@@ -64,6 +62,7 @@ pub async fn get_event_controller(
     let usecase = GetEventUseCase {
         event_id: path_params.event_id.clone(),
         user_id: user.id.clone(),
+        prefetched_calendar_event: None,
     };
 
     execute(usecase, &ctx)
@@ -76,6 +75,7 @@ pub async fn get_event_controller(
 pub struct GetEventUseCase {
     pub event_id: ID,
     pub user_id: ID,
+    pub prefetched_calendar_event: Option<CalendarEvent>,
 }
 
 #[derive(Debug)]
@@ -105,10 +105,13 @@ impl UseCase for GetEventUseCase {
     const NAME: &'static str = "GetEvent";
 
     async fn execute(&mut self, ctx: &NitteiContext) -> Result<Self::Response, Self::Error> {
-        let e = ctx.repos.events.find(&self.event_id).await.map_err(|e| {
-            tracing::error!("[get_event] Error finding event: {:?}", e);
-            UseCaseError::InternalError
-        })?;
+        let e = match &self.prefetched_calendar_event {
+            Some(event) => Some(event.clone()),
+            None => ctx.repos.events.find(&self.event_id).await.map_err(|e| {
+                tracing::error!("[get_event] Error finding event: {:?}", e);
+                UseCaseError::InternalError
+            })?,
+        };
         match e {
             Some(event) if event.user_id == self.user_id => Ok(event),
             _ => Err(UseCaseError::NotFound(self.event_id.clone())),

--- a/crates/api/src/event/get_event_instances.rs
+++ b/crates/api/src/event/get_event_instances.rs
@@ -5,7 +5,6 @@ use axum::{
 };
 use nittei_api_structs::get_event_instances::*;
 use nittei_domain::{
-    Account,
     CalendarEvent,
     EventInstance,
     ID,
@@ -21,7 +20,7 @@ use tracing::error;
 use crate::{
     error::NitteiError,
     shared::{
-        auth::{Policy, account_can_modify_event},
+        auth::Policy,
         usecase::{UseCase, execute},
     },
 };
@@ -42,16 +41,16 @@ use crate::{
     )
 )]
 pub async fn get_event_instances_admin_controller(
-    Extension(account): Extension<Account>,
-    path_params: Path<PathParams>,
+    Extension(event): Extension<CalendarEvent>,
     query_params: Query<QueryParams>,
     Extension(ctx): Extension<NitteiContext>,
 ) -> Result<Json<GetEventInstancesAPIResponse>, NitteiError> {
-    let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
+    // Not using the prefetched event by the route guard here
+    // As we need to fetch more data
 
     let usecase = GetEventInstancesUseCase {
-        user_id: e.user_id,
-        event_id: e.id,
+        user_id: event.user_id.clone(),
+        event_id: event.id.clone(),
         timespan: query_params.0,
     };
 

--- a/crates/api/src/event/get_upcoming_reminders.rs
+++ b/crates/api/src/event/get_upcoming_reminders.rs
@@ -485,6 +485,7 @@ mod tests {
         let update_event_usecase = DeleteEventUseCase {
             user,
             event_id: calendar_event.id,
+            prefetched_calendar_event: None,
         };
         execute(update_event_usecase, &ctx).await.unwrap();
         let new_reminders = ctx

--- a/crates/api/src/event/mod.rs
+++ b/crates/api/src/event/mod.rs
@@ -61,21 +61,28 @@ pub fn configure_routes() -> OpenApiRouter {
             get(get_event_by_external_id::get_event_by_external_id_admin_controller),
         )
         // Get a specific event by uid (admin route)
-        .route("/user/events/{event_id}", get(get_event_admin_controller))
+        .route(
+            "/user/events/{event_id}",
+            get(get_event_admin_controller)
+                .layer(axum::middleware::from_fn(auth::account_can_modify_event)),
+        )
         // Update an event by uid (admin route)
         .route(
             "/user/events/{event_id}",
-            put(update_event_admin_controller),
+            put(update_event_admin_controller)
+                .layer(axum::middleware::from_fn(auth::account_can_modify_event)),
         )
         // Delete an event by uid (admin route)
         .route(
             "/user/events/{event_id}",
-            delete(delete_event_admin_controller),
+            delete(delete_event_admin_controller)
+                .layer(axum::middleware::from_fn(auth::account_can_modify_event)),
         )
         // Get event instances (admin route)
         .route(
             "/user/events/{event_id}/instances",
-            get(get_event_instances_admin_controller),
+            get(get_event_instances_admin_controller)
+                .layer(axum::middleware::from_fn(auth::account_can_modify_event)),
         )
         // Admin delete many events
         .route(

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -139,6 +139,7 @@ pub async fn update_event_controller(
         .map_err(NitteiError::from)
 }
 
+/// Use case for updating an event
 #[derive(Debug, Default)]
 pub struct UpdateEventUseCase {
     pub user: User,
@@ -165,7 +166,8 @@ pub struct UpdateEventUseCase {
     pub created: Option<DateTime<Utc>>,
     pub updated: Option<DateTime<Utc>>,
 
-    // Prefetched event by the route guard, if any
+    /// Event that has been potentially prefetched by the route guard
+    /// Only happens in the admin controller
     pub prefetched_calendar_event: Option<CalendarEvent>,
 }
 

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -19,7 +19,7 @@ use crate::{
     error::NitteiError,
     event::{self, subscribers::UpdateSyncedEventsOnEventUpdated},
     shared::{
-        auth::{Permission, Policy, account_can_modify_event, account_can_modify_user},
+        auth::{Permission, Policy, account_can_modify_user},
         usecase::{PermissionBoundary, Subscriber, UseCase, execute, execute_with_policy},
     },
 };
@@ -44,17 +44,16 @@ use crate::{
 )]
 pub async fn update_event_admin_controller(
     Extension(account): Extension<Account>,
-    path_params: Path<PathParams>,
+    Extension(event): Extension<CalendarEvent>,
     Extension(ctx): Extension<NitteiContext>,
     body: Valid<Json<UpdateEventRequestBody>>,
 ) -> Result<Json<APIResponse>, NitteiError> {
-    let e = account_can_modify_event(&account, &path_params.event_id, &ctx).await?;
-    let user = account_can_modify_user(&account, &e.user_id, &ctx).await?;
+    let user = account_can_modify_user(&account, &event.user_id, &ctx).await?;
 
     let mut body = body.0;
     let usecase = UpdateEventUseCase {
         user,
-        event_id: e.id,
+        event_id: event.id.clone(),
         title: body.title.take(),
         description: body.description.take(),
         event_type: body.event_type.take(),
@@ -75,6 +74,9 @@ pub async fn update_event_admin_controller(
         metadata: body.metadata.take(),
         created: body.created,
         updated: body.updated,
+
+        // Prefetched event by the route guard
+        prefetched_calendar_event: Some(event),
     };
 
     execute(usecase, &ctx)
@@ -128,6 +130,7 @@ pub async fn update_event_controller(
         metadata: body.metadata.take(),
         created: body.created,
         updated: body.updated,
+        prefetched_calendar_event: None,
     };
 
     execute_with_policy(usecase, &policy, &ctx)
@@ -161,6 +164,9 @@ pub struct UpdateEventUseCase {
     pub metadata: Option<serde_json::Value>,
     pub created: Option<DateTime<Utc>>,
     pub updated: Option<DateTime<Utc>>,
+
+    // Prefetched event by the route guard, if any
+    pub prefetched_calendar_event: Option<CalendarEvent>,
 }
 
 #[derive(Debug)]
@@ -221,19 +227,30 @@ impl UseCase for UpdateEventUseCase {
             metadata,
             created,
             updated,
+            prefetched_calendar_event,
         } = self;
 
-        let mut e = match ctx.repos.events.find(event_id).await {
-            Ok(Some(event)) if event.user_id == user.id => event,
-            Ok(_) => {
+        let e = match &prefetched_calendar_event {
+            Some(event) => Some(event.clone()),
+            None => ctx.repos.events.find(event_id).await.map_err(|e| {
+                tracing::error!("[update_event] Error finding event: {:?}", e);
+                UseCaseError::StorageError
+            })?,
+        };
+
+        let mut e = match e {
+            Some(event) if event.user_id == user.id => event,
+            Some(_) => {
                 return Err(UseCaseError::NotFound(
                     "Calendar Event".into(),
                     event_id.clone(),
                 ));
             }
-            Err(e) => {
-                tracing::error!("Failed to get one event {:?}", e);
-                return Err(UseCaseError::StorageError);
+            None => {
+                return Err(UseCaseError::NotFound(
+                    "Calendar Event".into(),
+                    event_id.clone(),
+                ));
             }
         };
 

--- a/crates/api/src/shared/auth/route_guards.rs
+++ b/crates/api/src/shared/auth/route_guards.rs
@@ -288,8 +288,8 @@ pub async fn account_can_modify_calendar(
     }
 }
 
-/// Used for account admin routes by checking that account
-/// is not modifying an event in another account
+/// Used for admin routes for calendar events
+/// It checks if the acc can access/modify the event
 ///
 /// Store the event in the request extensions
 #[instrument(name = "auth::account_can_modify_event", skip_all)]

--- a/crates/api/src/shared/auth/route_guards.rs
+++ b/crates/api/src/shared/auth/route_guards.rs
@@ -1,4 +1,10 @@
-use axum::{Extension, extract::Request, http::HeaderMap, middleware::Next, response::Response};
+use axum::{
+    Extension,
+    extract::{Path, Request},
+    http::HeaderMap,
+    middleware::Next,
+    response::Response,
+};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use nittei_domain::{Account, Calendar, CalendarEvent, ID, Schedule, User};
 use nittei_infra::NitteiContext;
@@ -284,8 +290,28 @@ pub async fn account_can_modify_calendar(
 
 /// Used for account admin routes by checking that account
 /// is not modifying an event in another account
+///
+/// Store the event in the request extensions
 #[instrument(name = "auth::account_can_modify_event", skip_all)]
 pub async fn account_can_modify_event(
+    Extension(account): Extension<Account>,
+    Path(event_id): Path<ID>,
+    Extension(ctx): Extension<NitteiContext>,
+    request: Request,
+    next: Next,
+) -> Result<Response, NitteiError> {
+    let event = account_can_modify_event_inner(&account, &event_id, &ctx).await?;
+
+    // Inject the event into the request extensions
+    let mut request = request;
+    request.extensions_mut().insert(event);
+
+    // Run the next middleware or the final handler
+    Ok(next.run(request).await)
+}
+
+/// Inner function for checking that account is not modifying an event in another account
+pub async fn account_can_modify_event_inner(
     account: &Account,
     event_id: &ID,
     ctx: &NitteiContext,


### PR DESCRIPTION
### Changed
- Re-use the `calendar_event` fetched in the "hook" (now adapted to middleware) instead of re-querying the DB
  - For some endpoints, we fetch the `calendar_event` in a hook in order to check beforehand that the account can access/update that event, however that event was then discarded, and then refetched inside the endpoint itself
  - Instead, use the event we have already fetched 