### PR TITLE
feat: allow to specify number of workers and print runtime info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1630,7 @@ dependencies = [
  "nittei_infra",
  "nittei_sdk",
  "nittei_utils",
+ "num_cpus",
  "opentelemetry",
  "opentelemetry-datadog",
  "opentelemetry-otlp",
@@ -1828,6 +1835,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/bins/nittei/Cargo.toml
+++ b/bins/nittei/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = "1.0"
 axum = "0.8"
 
 tokio = { version = "1", features = ["full"] }
+num_cpus = "1"
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [

--- a/bins/nittei/src/main.rs
+++ b/bins/nittei/src/main.rs
@@ -1,6 +1,7 @@
 use nittei::telemetry::init_subscriber;
 use nittei_api::Application;
 use nittei_infra::setup_context;
+use nittei_utils::config;
 use tikv_jemallocator::Jemalloc;
 use tokio::signal;
 use tracing::info;
@@ -20,21 +21,32 @@ fn main() {
         "current_thread" => {
             #[allow(clippy::unwrap_used)]
             let _ = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
+                .enable_all() // Enable all features
                 .build()
                 .unwrap()
                 .block_on(run());
         }
         "multi_thread" => {
+            let mut runtime = tokio::runtime::Builder::new_multi_thread();
+
+            // Enable all features
+            let mut runtime = runtime.enable_all();
+
+            // If the number of workers is set, use it
+            // Otherwise, use the number of cores (Tokio default)
+            if let Some(num_workers) =
+                nittei_utils::config::APP_CONFIG.tokio_runtime_number_of_workers
+            {
+                let num_workers = num_workers.max(1); // Ensure at least 1 worker
+                runtime = runtime.worker_threads(num_workers);
+            }
+
+            // Build the runtime and block on the run function
             #[allow(clippy::unwrap_used)]
-            let _ = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(run());
+            let _ = runtime.build().unwrap().block_on(run());
         }
         _ => {
-            eprintln!("Invalid tokio runtime flavor: {runtime_flavor}");
+            eprintln!("[start_runtime] Invalid tokio runtime flavor: {runtime_flavor}");
             std::process::exit(1);
         }
     }
@@ -44,6 +56,8 @@ fn main() {
 async fn run() -> anyhow::Result<()> {
     // Initialize the subscriber for logging & tracing
     init_subscriber()?;
+
+    print_runtime_info();
 
     let context = setup_context().await?;
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
@@ -83,4 +97,66 @@ async fn run() -> anyhow::Result<()> {
     info!("[main_shutdown_handler] shutdown complete");
 
     Ok(())
+}
+
+/// Print the runtime info
+/// This is used to print the number of CPUs and the memory quota assigned to the container
+fn print_runtime_info() {
+    if !nittei_utils::config::APP_CONFIG.print_runtime_info {
+        return;
+    }
+
+    let runtime = config::APP_CONFIG.tokio_runtime_flavor.as_str();
+    tracing::info!("[print_runtime_info] Tokio runtime flavor: {runtime}");
+
+    let number_of_cpus = num_cpus::get();
+    tracing::info!("[print_runtime_info] Number of CPUs detected: {number_of_cpus}");
+
+    // If the runtime is multi_thread, print the number of workers
+    if runtime == "multi_thread" {
+        let number_of_workers = match config::APP_CONFIG.tokio_runtime_number_of_workers {
+            Some(number_of_workers) => number_of_workers,
+            None => number_of_cpus,
+        };
+        tracing::info!("[print_runtime_info] Number of workers: {number_of_workers}");
+    }
+
+    if let Some(number_of_logical_cpus) = read_cpu_quota() {
+        tracing::info!(
+            "[print_runtime_info] Number of logical CPUs assigned to the container: {number_of_logical_cpus}"
+        );
+    }
+    if let Some(memory_quota) = read_memory_quota() {
+        tracing::info!(
+            "[print_runtime_info] Memory quota assigned to the container: {memory_quota}"
+        );
+    }
+}
+
+/// Read the memory quota from the cgroup
+/// This is used to limit the memory usage
+/// If the quota is not set, return None
+/// If the quota is set, return the memory quota in bytes
+fn read_memory_quota() -> Option<f64> {
+    use std::fs::read_to_string;
+    let quota = read_to_string("/sys/fs/cgroup/memory.max").ok()?;
+    let mut parts = quota.split_whitespace();
+    let quota_bytes: f64 = parts.next()?.parse().ok()?;
+    Some(quota_bytes)
+}
+
+/// Read the cpu quota from the cgroup
+/// This is used to limit the number of workers
+/// If the quota is not set, return None
+/// If the quota is set, return the number of logical CPUs
+///
+/// Can be useful to know what is the max number of workers that can be used
+fn read_cpu_quota() -> Option<f64> {
+    use std::fs::read_to_string;
+
+    let quota = read_to_string("/sys/fs/cgroup/cpu.max").ok()?;
+    let mut parts = quota.split_whitespace();
+    let quota_us: f64 = parts.next()?.parse().ok()?;
+    let period_us: f64 = parts.next()?.parse().ok()?;
+    Some(quota_us / period_us) // in logical CPUs
 }

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -13,6 +13,17 @@ pub struct AppConfig {
     /// Env var: NITTEI__TOKIO_RUNTIME_FLAVOR
     pub tokio_runtime_flavor: String,
 
+    /// The tokio runtime number of workers
+    /// This is only used if the runtime flavor is "multi_thread"
+    /// Default is None, which means the number of workers will be the number of cores (Tokio default)
+    /// Env var: NITTEI__TOKIO_RUNTIME_NUMBER_OF_WORKERS
+    pub tokio_runtime_number_of_workers: Option<usize>,
+
+    /// This is a flag to print the runtime info
+    /// Default is false
+    /// Env var: NITTEI__PRINT_RUNTIME_INFO
+    pub print_runtime_info: bool,
+
     //// The host to bind the HTTP server to
     //// Default is 127.0.0.1
     //// Env var: NITTEI__HTTP_HOST
@@ -194,6 +205,8 @@ fn parse_config() -> AppConfig {
                 .try_parsing(true)
                 .separator("__"),
         )
+        .set_default("print_runtime_info", false)
+        .expect("Failed to set default print_runtime_info")
         .set_default("tokio_runtime_flavor", "multi_thread")
         .expect("Failed to set default tokio_runtime_flavor")
         .set_default("http_host", "127.0.0.1")


### PR DESCRIPTION
### Changed
- Allow to specify the number of workers for the Tokio multi_thread runtime
- Add a way to get additional runtime information (number of cores/workers/logical cpus assigned by OS and memory)