### PR TITLE
fix: chart topology spread constraints

### DIFF
--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -47,8 +47,6 @@ spec:
   selector:
     matchLabels:
       {{- include "nittei.selectorLabels" . | nindent 6 }}
-  topologySpreadConstraints:
-    {{- toYaml .Values.topologySpreadConstraints | nindent 4 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -140,5 +138,9 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
### Changed
- Fix `topologySpreadConstraints` position in the deployment config