### PR TITLE
fix: also include events now planned during timespan

### DIFF
--- a/crates/infra/.sqlx/query-b01c514da6037175c6d6c4c0c2ffedd0b23035fabf4b8c4900c187880ad44e7e.json
+++ b/crates/infra/.sqlx/query-b01c514da6037175c6d6c4c0c2ffedd0b23035fabf4b8c4900c187880ad44e7e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n            WHERE e.recurring_event_uid = ANY($1::uuid[]) AND e.original_start_time >= $2 AND e.original_start_time <= $3\n            ",
+  "query": "\n            SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n            WHERE e.recurring_event_uid = ANY($1::uuid[]) AND\n                (\n                    (e.original_start_time >= $2 AND e.original_start_time <= $3)\n                    OR\n                    (e.start_time >= $2 AND e.start_time <= $3)\n                )\n            ",
   "describe": {
     "columns": [
       {
@@ -170,5 +170,5 @@
       false
     ]
   },
-  "hash": "c5f22002d2485e5a353f3e6ac23d8699b3ad7b9cc3365b0a166a2c97da36188d"
+  "hash": "b01c514da6037175c6d6c4c0c2ffedd0b23035fabf4b8c4900c187880ad44e7e"
 }

--- a/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -452,7 +452,12 @@ impl IEventRepo for PostgresEventRepo {
             EventRaw,
             r#"
             SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e
-            WHERE e.recurring_event_uid = ANY($1::uuid[]) AND e.original_start_time >= $2 AND e.original_start_time <= $3
+            WHERE e.recurring_event_uid = ANY($1::uuid[]) AND
+                (
+                    (e.original_start_time >= $2 AND e.original_start_time <= $3)
+                    OR
+                    (e.start_time >= $2 AND e.start_time <= $3)
+                )
             "#,
             &recurring_event_ids as &[Uuid],
             timespan.start(),


### PR DESCRIPTION
### Changed
- Fix the logic for fetching of exceptions of recurring events
  - Now include both the ones that have `original_start_time` inside the timespan, and the ones that have `start_time` inside, but `original_start_time` outside (as they also impact the timespan)