### PR TITLE
fix: avoid capturing stack traces in hotpaths

### DIFF
--- a/crates/api/src/account/get_account.rs
+++ b/crates/api/src/account/get_account.rs
@@ -29,7 +29,7 @@ pub async fn get_account_controller(
         .find(&account_possibly_stale.id)
         .await
         .map_err(|_| NitteiError::InternalError)?
-        .ok_or(NitteiError::NotFound("Account not found".to_string()))?;
+        .ok_or_else(|| NitteiError::NotFound("Account not found".to_string()))?;
 
     Ok(Json(APIResponse::new(account)))
 }

--- a/crates/api/src/event/create_batch_events.rs
+++ b/crates/api/src/event/create_batch_events.rs
@@ -185,7 +185,7 @@ impl UseCase for CreateBatchEventsUseCase {
             let calendar = calendars
                 .iter()
                 .find(|c| c.id == event.calendar_id)
-                .ok_or(UseCaseError::NotFound(event.calendar_id.clone()))?;
+                .ok_or_else(|| UseCaseError::NotFound(event.calendar_id.clone()))?;
             if calendar.user_id != event.user.id {
                 return Err(UseCaseError::NotFound(event.calendar_id.clone()));
             }

--- a/crates/api/src/event/get_event_instances.rs
+++ b/crates/api/src/event/get_event_instances.rs
@@ -155,10 +155,8 @@ impl UseCase for GetEventInstancesUseCase {
         let main_event = event_and_exceptions.iter().find(|e| e.id == self.event_id);
 
         // If the main event is not found, return an error
-        let main_event = main_event.ok_or(UseCaseError::NotFound(
-            "CalendarEvent".into(),
-            self.event_id.clone(),
-        ))?;
+        let main_event = main_event
+            .ok_or_else(|| UseCaseError::NotFound("CalendarEvent".into(), self.event_id.clone()))?;
 
         // If the user_id of the main event is different from the user_id of the user, return an error
         if self.user_id != main_event.user_id {


### PR DESCRIPTION
### Changed
- Adapted a few places so that the errors are created lazily instead of eagerly
  - Avoids paying the cost of capturing (uselessly) the stack trace in happy paths

### Context
- Profile shows that under load, most of the CPU is spent in `try_from` function of `CalendarEvent`, and particularly for anyhow's errors, even though the number of errors is very low
 
<img width="1450" height="785" alt="image" src="https://github.com/user-attachments/assets/febd3e91-34cf-46b4-bc10-a1e3c3c67ba2" />
