### PR TITLE
fix: disable brotli compression

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -147,7 +147,9 @@ impl Application {
                     .layer(SetSensitiveHeadersLayer::new(sensitive_headers))
                     .layer(CorsLayer::permissive())
                     .layer(RequestDecompressionLayer::new())
-                    .layer(CompressionLayer::new())
+                    // Disabling Brotli as it seems to be causing slowdowns for big responses and is more CPU heavy than gzip
+                    // For backend to backend communication, we can use gzip instead
+                    .layer(CompressionLayer::new().br(false))
                     // Catch panics and convert them into responses.
                     .layer(CatchPanicLayer::new())
                     .layer(


### PR DESCRIPTION
### Changed
- Test performance with Brotli compression disabled, as we are seeing some relatively high CPU and memory usage linked to it
  - It could be normal, just curious to see if `gzip` is a better compromise for backend to backend (zstd would be nice too, but NodeJS doesn't support it in v22)