### PR TITLE
fix: adapt ignore logic for metrics & healthchecks

### DIFF
--- a/crates/api/src/http_logger.rs
+++ b/crates/api/src/http_logger.rs
@@ -5,11 +5,15 @@ use axum::{
     middleware::Next,
     response::Response as AxumResponse,
 };
+use nittei_utils::config::APP_CONFIG;
 use opentelemetry::global::{self};
 use opentelemetry_http::HeaderExtractor;
 use tower_http::trace::{MakeSpan, OnFailure, OnResponse};
 use tracing::{Span, field::Empty};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+const PATHS_TO_EXCLUDE_FROM_LOGGING_AND_TRACING: [&str; 2] =
+    ["/api/v1/healthcheck", "/api/v1/metrics"];
 
 /// Metadata for the request
 /// Used for logging and tracing
@@ -57,7 +61,14 @@ impl<B> MakeSpan<B> for NitteiTracingSpanBuilder {
             .map(|r| r.as_str().to_string())
             .unwrap_or_default();
 
-        if path == "/api/v1/healthcheck" {
+        // By default, exclude health check and metrics from tracing
+        if PATHS_TO_EXCLUDE_FROM_LOGGING_AND_TRACING.contains(&path)
+            && !APP_CONFIG
+                .observability
+                .as_ref()
+                .map(|o| o.observe_status_endpoints)
+                .unwrap_or_default()
+        {
             return Span::none();
         }
 
@@ -116,8 +127,16 @@ impl<B> OnResponse<B> for NitteiTracingOnResponse {
             ("ok", tracing::Level::INFO)
         };
 
-        // Exclude health check from logging
-        if path == "/api/v1/healthcheck" && status_code == 200 {
+        // By default, exclude health check from logging
+        // Only exclude if status code is 200
+        if PATHS_TO_EXCLUDE_FROM_LOGGING_AND_TRACING.contains(&path)
+            && status_code == 200
+            && !APP_CONFIG
+                .observability
+                .as_ref()
+                .map(|o| o.observe_status_endpoints)
+                .unwrap_or_default()
+        {
             return;
         }
 

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -122,6 +122,12 @@ pub struct ObservabilityConfig {
     /// The Datadog tracing endpoint
     /// Env var: NITTEI__OBSERVABILITY__DATADOG_TRACING_ENDPOINT
     pub datadog_tracing_endpoint: Option<String>,
+
+    /// This is a flag to enabling observability on status endpoints
+    /// Ex: health check and metrics endpoints
+    /// Default is false
+    /// Env var: NITTEI__OBSERVABILITY__OBSERVE_STATUS_ENDPOINTS
+    pub observe_status_endpoints: bool,
 }
 
 /// Account configuration
@@ -242,6 +248,8 @@ fn parse_config() -> AppConfig {
             "postgresql://postgres:postgres@localhost:45432/nittei",
         )
         .expect("Failed to set default pg.database_url")
+        .set_default("observability.observe_status_endpoints", false)
+        .expect("Failed to set default observability.observe_status_endpoints")
         .build()
         .expect("Failed to build the configuration object");
 


### PR DESCRIPTION
### Changed
- Adapt logic for ignoring healthchecks and metrics endpoints when logging/tracing
  - Add env var so that it can still be enabled