### PR TITLE
fix(telemetry config): simplify default values

### DIFF
--- a/bins/nittei/src/telemetry.rs
+++ b/bins/nittei/src/telemetry.rs
@@ -24,17 +24,11 @@ pub fn init_subscriber() -> anyhow::Result<()> {
             .with_env_filter(env_filter)
             .init();
     } else {
-        let observability_config = nittei_utils::config::APP_CONFIG.observability.as_ref();
+        let observability_config = &nittei_utils::config::APP_CONFIG.observability;
         // In production, use the JSON format for logs
-        let service_name = observability_config
-            .and_then(|o| o.service_name.clone())
-            .unwrap_or_else(|| "unknown service".to_string());
-        let service_version = observability_config
-            .and_then(|o| o.service_version.clone())
-            .unwrap_or_else(|| "unknown version".to_string());
-        let service_env = observability_config
-            .and_then(|o| o.service_env.clone())
-            .unwrap_or_else(|| "unknown env".to_string());
+        let service_name = &observability_config.service_name;
+        let service_version = &observability_config.service_version;
+        let service_env = &observability_config.service_env;
 
         // Set the global propagator to trace context propagator
         let composite = TextMapCompositePropagator::new(vec![
@@ -45,8 +39,11 @@ pub fn init_subscriber() -> anyhow::Result<()> {
         global::set_text_map_propagator(composite);
 
         // Get the tracer - if no endpoint is provided, tracing will be disabled
-        let tracer_provider =
-            get_tracer_provider(service_name.clone(), service_version, service_env)?;
+        let tracer_provider = get_tracer_provider(
+            service_name.to_owned(),
+            service_version.to_owned(),
+            service_env.to_owned(),
+        )?;
 
         // Create a telemetry layer if a tracer is available
         let telemetry_layer = tracer_provider.map(|tracer_provider| {
@@ -87,25 +84,23 @@ fn get_tracer_provider(
     service_version: String,
     service_env: String,
 ) -> anyhow::Result<Option<SdkTracerProvider>> {
-    let otlp_endpoint = nittei_utils::config::APP_CONFIG
+    let otlp_endpoint = &nittei_utils::config::APP_CONFIG
         .observability
-        .as_ref()
-        .and_then(|o| o.otlp_tracing_endpoint.clone());
-    let datadog_endpoint = nittei_utils::config::APP_CONFIG
+        .otlp_tracing_endpoint;
+    let datadog_endpoint = &nittei_utils::config::APP_CONFIG
         .observability
-        .as_ref()
-        .and_then(|o| o.datadog_tracing_endpoint.clone());
+        .datadog_tracing_endpoint;
 
     if let Some(datadog_endpoint) = datadog_endpoint {
         Ok(Some(get_tracer_datadog(
-            datadog_endpoint,
+            datadog_endpoint.to_owned(),
             service_name,
             service_version,
             service_env,
         )?))
     } else if let Some(otlp_endpoint) = otlp_endpoint {
         Ok(Some(get_tracer_otlp(
-            otlp_endpoint,
+            otlp_endpoint.to_owned(),
             service_name,
             service_version,
             service_env,
@@ -179,12 +174,10 @@ fn get_tracer_otlp(
 /// This is a parent-based sampler, so if a parent exists, always sample
 /// If there is no parent, then this is based on the TRACING_SAMPLE_RATIO env var, defaults to 0.1
 fn get_sampler() -> Sampler {
-    // Get the sample ratio from the env var, default to 0.1
+    // Get the sample ratio from the env var, default is 0.1
     let ratio_to_sample = nittei_utils::config::APP_CONFIG
         .observability
-        .as_ref()
-        .and_then(|o| o.tracing_sample_rate)
-        .unwrap_or(0.1);
+        .tracing_sample_rate;
 
     // Create sampler based on
     // (1) parent => so if parent exists always sample

--- a/crates/api/src/http_logger.rs
+++ b/crates/api/src/http_logger.rs
@@ -63,11 +63,7 @@ impl<B> MakeSpan<B> for NitteiTracingSpanBuilder {
 
         // By default, exclude health check and metrics from tracing
         if PATHS_TO_EXCLUDE_FROM_LOGGING_AND_TRACING.contains(&path)
-            && !APP_CONFIG
-                .observability
-                .as_ref()
-                .map(|o| o.observe_status_endpoints)
-                .unwrap_or_default()
+            && !APP_CONFIG.observability.observe_status_endpoints
         {
             return Span::none();
         }
@@ -131,11 +127,7 @@ impl<B> OnResponse<B> for NitteiTracingOnResponse {
         // Only exclude if status code is 200
         if PATHS_TO_EXCLUDE_FROM_LOGGING_AND_TRACING.contains(&path)
             && status_code == 200
-            && !APP_CONFIG
-                .observability
-                .as_ref()
-                .map(|o| o.observe_status_endpoints)
-                .unwrap_or_default()
+            && !APP_CONFIG.observability.observe_status_endpoints
         {
             return;
         }

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -88,7 +88,7 @@ pub struct AppConfig {
 
     /// The observability configuration
     /// This is used to configure the observability tools
-    pub observability: Option<ObservabilityConfig>,
+    pub observability: ObservabilityConfig,
 }
 
 /// Observability configuration
@@ -98,22 +98,22 @@ pub struct ObservabilityConfig {
     /// Service name for the tracing
     /// Default is "unknown service"
     /// Env var: NITTEI__OBSERVABILITY__SERVICE_NAME
-    pub service_name: Option<String>,
+    pub service_name: String,
 
     /// Service version for the tracing
     /// Default is "unknown version"
     /// Env var: NITTEI__OBSERVABILITY__SERVICE_VERSION
-    pub service_version: Option<String>,
+    pub service_version: String,
 
     /// Service environment for the tracing
     /// Default is "unknown env"
     /// Env var: NITTEI__OBSERVABILITY__SERVICE_ENV
-    pub service_env: Option<String>,
+    pub service_env: String,
 
     /// The tracing sample rate
     /// Default is 0.1
     /// Env var: NITTEI__OBSERVABILITY__TRACING_SAMPLE_RATE
-    pub tracing_sample_rate: Option<f64>,
+    pub tracing_sample_rate: f64,
 
     /// The OTLP tracing endpoint
     /// Env var: NITTEI__OBSERVABILITY__OTLP_TRACING_ENDPOINT
@@ -248,8 +248,17 @@ fn parse_config() -> AppConfig {
             "postgresql://postgres:postgres@localhost:45432/nittei",
         )
         .expect("Failed to set default pg.database_url")
+        // Observability
+        .set_default("observability.service_name", "unknown service")
+        .expect("Failed to set default observability.service_name")
+        .set_default("observability.service_version", "unknown version")
+        .expect("Failed to set default observability.service_version")
+        .set_default("observability.service_env", "unknown env")
+        .expect("Failed to set default observability.service_env")
         .set_default("observability.observe_status_endpoints", false)
         .expect("Failed to set default observability.observe_status_endpoints")
+        .set_default("observability.tracing_sample_rate", 0.1)
+        .expect("Failed to set default observability.tracing_sample_rate")
         .build()
         .expect("Failed to build the configuration object");
 


### PR DESCRIPTION
### Changed
- [config] Simply a little how the configuration for observability is handled
  - Keep the default values in the config.rs file, instead of having them in multiple places