### PR TITLE
feat: add flag for fully disabling tracing

### DIFF
--- a/bins/nittei/src/telemetry.rs
+++ b/bins/nittei/src/telemetry.rs
@@ -179,6 +179,14 @@ fn get_sampler() -> Sampler {
         .observability
         .tracing_sample_rate;
 
+    // If tracing is disabled, return an always off sampler
+    if nittei_utils::config::APP_CONFIG
+        .observability
+        .disable_tracing
+    {
+        return Sampler::AlwaysOff;
+    }
+
     // Create sampler based on
     // (1) parent => so if parent exists always sample
     // (2) if no parent, then the trace id ratio

--- a/crates/utils/src/config.rs
+++ b/crates/utils/src/config.rs
@@ -110,6 +110,11 @@ pub struct ObservabilityConfig {
     /// Env var: NITTEI__OBSERVABILITY__SERVICE_ENV
     pub service_env: String,
 
+    /// This is a flag to disable tracing
+    /// Default is false
+    /// Env var: NITTEI__OBSERVABILITY__DISABLE_TRACING
+    pub disable_tracing: bool,
+
     /// The tracing sample rate
     /// Default is 0.1
     /// Env var: NITTEI__OBSERVABILITY__TRACING_SAMPLE_RATE
@@ -259,6 +264,8 @@ fn parse_config() -> AppConfig {
         .expect("Failed to set default observability.observe_status_endpoints")
         .set_default("observability.tracing_sample_rate", 0.1)
         .expect("Failed to set default observability.tracing_sample_rate")
+        .set_default("observability.disable_tracing", false)
+        .expect("Failed to set default observability.disable_tracing")
         .build()
         .expect("Failed to build the configuration object");
 


### PR DESCRIPTION
### Changed
- For some use cases, it's useful to fully disable the tracing (e.g. when running scripts, to avoid increased costs)
 - Added a env var to fully disable tracing 