### PR TITLE
feat: re-add spans on `execute`, but as `debug` + use max config for searches

### DIFF
--- a/crates/api/src/account/account_search_events.rs
+++ b/crates/api/src/account/account_search_events.rs
@@ -57,7 +57,9 @@ pub async fn account_search_events_controller(
         created_at: body.filter.created_at.take(),
         updated_at: body.filter.updated_at.take(),
         sort: body.sort.take(),
-        limit: body.limit.or(Some(1000)), // Default limit to 1000
+        limit: body
+            .limit
+            .or(Some(APP_CONFIG.max_events_returned_by_search)),
     };
 
     execute(usecase, &ctx)

--- a/crates/api/src/event/search_events.rs
+++ b/crates/api/src/event/search_events.rs
@@ -57,7 +57,9 @@ pub async fn search_events_controller(
         created_at: body.filter.created_at.take(),
         updated_at: body.filter.updated_at.take(),
         sort: body.sort.take(),
-        limit: body.limit.or(Some(1000)), // Default limit to 1000
+        limit: body
+            .limit
+            .or(Some(APP_CONFIG.max_events_returned_by_search)),
     };
 
     execute(usecase, &ctx)

--- a/crates/api/src/shared/usecase.rs
+++ b/crates/api/src/shared/usecase.rs
@@ -56,6 +56,7 @@ where
     }
 }
 
+#[tracing::instrument(level = "debug", name = "UseCase executed by User", skip(usecase, policy, ctx), fields(usecase = %U::NAME))]
 pub async fn execute_with_policy<U>(
     usecase: U,
     policy: &Policy,
@@ -79,6 +80,7 @@ where
         .map_err(UseCaseErrorContainer::UseCase)
 }
 
+#[tracing::instrument(level = "debug", name = "UseCase executed by Account", skip(usecase, ctx), fields(usecase = %U::NAME))]
 pub async fn execute<U>(usecase: U, ctx: &NitteiContext) -> Result<U::Response, U::Error>
 where
     U: UseCase + Send,


### PR DESCRIPTION
### Changed
- Re-add tracing/instrumentation on the main `execute` functions, but set the level to `DEBUG`
- Instead of using undocumented `1000` value for the default limit on searches, use the configured `max`