### PR TITLE
feat: add link to Rust page + add a "going further" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ This will install
 - [tracing](https://github.com/tokio-rs/tracing): handles tracing and logging
 - [tikv-jemallocator](https://github.com/tikv/jemallocator): replaces default memory allocator with Jemalloc
 
+## New to Rust
+
+You can check [docs/rust.md](./docs/rust.md) to get a small introduction to Rust.
+
 ## Contributing
 
 Contributions are welcome and are greatly appreciated!

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -157,3 +157,14 @@ tokio = { version = "1.0", features = ["full"] }
 ### ✅ When in doubt, check the compiler
 
 Rust’s compiler is very strict — but its error messages are famously helpful. Trust it!
+
+## Going further
+
+Resources that can help when learning, or just developing in Rust
+
+- [Official Rust book](https://doc.rust-lang.org/book/)
+- [Official page for crates](https://crates.io/)
+- [Official page for crates' docs](https://docs.rs/)
+- [Rust cheat sheet](https://cheats.rs/)
+- [Guide to the ecosystem](https://blessed.rs/crates)
+- [Awesome Rust repository](https://github.com/rust-unofficial/awesome-rust)


### PR DESCRIPTION
### Changed
- Link to the Rust.md page in the main readme
- Add a "Going further" section 