### PR TITLE
[Breaking Change] feat: remove updateEventV2 endpoint

### DIFF
--- a/clients/javascript/lib/eventClient.ts
+++ b/clients/javascript/lib/eventClient.ts
@@ -56,26 +56,6 @@ export class NitteiEventClient extends NitteiBaseClient {
   }
 
   /**
-   * Update an event (V2)
-   * @param eventId - id of the event
-   * @param data - data of the event
-   * @returns - the updated event
-   */
-  public async updateV2(
-    eventId: ID,
-    data: UpdateEventRequestBody
-  ): Promise<CalendarEventResponse> {
-    const res = await this.patch<CalendarEventResponse>(
-      `/user/events_v2/${eventId}`,
-      data
-    )
-
-    return {
-      event: convertEventDates(res.event),
-    }
-  }
-
-  /**
    * Create a new calendar event
    * @param userId - id of the user
    * @param data - data of the event

--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -398,7 +398,7 @@ describe('CalendarEvent API', () => {
       expect(res2.event.updated).toEqual(new Date(0))
     })
 
-    it('should be able to update event with v2 endpoint (PATCH behavior)', async () => {
+    it('should be able to update event with PATCH behavior', async () => {
       const res = await adminClient.events.create(userId, {
         calendarId,
         duration: 1000,
@@ -417,7 +417,7 @@ describe('CalendarEvent API', () => {
       const eventId = res.event.id
 
       // Test partial update - only update title and duration
-      const res2 = await adminClient.events.updateV2(eventId, {
+      const res2 = await adminClient.events.update(eventId, {
         title: 'updated title',
         duration: 2000,
       })
@@ -438,7 +438,7 @@ describe('CalendarEvent API', () => {
       expect(res2.event.busy).toBe(true)
     })
 
-    it('should be able to set optional fields to NULL with v2 endpoint', async () => {
+    it('should be able to set optional fields to NULL', async () => {
       const res = await adminClient.events.create(userId, {
         calendarId,
         duration: 1000,
@@ -455,7 +455,7 @@ describe('CalendarEvent API', () => {
       const eventId = res.event.id
 
       // Test setting optional fields to NULL
-      const res2 = await adminClient.events.updateV2(eventId, {
+      const res2 = await adminClient.events.update(eventId, {
         title: null,
         description: null,
         eventType: null,
@@ -483,7 +483,7 @@ describe('CalendarEvent API', () => {
       expect(res2.event.busy).toBe(true)
     })
 
-    it('should be able to update exdates and reminders with v2 endpoint', async () => {
+    it('should be able to update exdates and reminders', async () => {
       const res = await adminClient.events.create(userId, {
         calendarId,
         duration: 1000,
@@ -494,7 +494,7 @@ describe('CalendarEvent API', () => {
       const eventId = res.event.id
 
       // Test updating exdates and reminders
-      const res2 = await adminClient.events.updateV2(eventId, {
+      const res2 = await adminClient.events.update(eventId, {
         exdates: [new Date(3000), new Date(4000)],
         reminders: [{ delta: 30, identifier: 'reminder-2' }],
       })
@@ -505,7 +505,7 @@ describe('CalendarEvent API', () => {
       ])
 
       // Test setting to empty arrays
-      const res3 = await adminClient.events.updateV2(eventId, {
+      const res3 = await adminClient.events.update(eventId, {
         exdates: [],
         reminders: [],
       })
@@ -514,7 +514,7 @@ describe('CalendarEvent API', () => {
       expect(res3.event.reminders).toEqual([])
     })
 
-    it('should handle recurrence updates with v2 endpoint', async () => {
+    it('should handle recurrence updates', async () => {
       const res = await adminClient.events.create(userId, {
         calendarId,
         duration: 1000,
@@ -528,7 +528,7 @@ describe('CalendarEvent API', () => {
       const eventId = res.event.id
 
       // Test updating recurrence
-      const res2 = await adminClient.events.updateV2(eventId, {
+      const res2 = await adminClient.events.update(eventId, {
         recurrence: {
           freq: 'weekly',
           interval: 2,
@@ -545,14 +545,14 @@ describe('CalendarEvent API', () => {
       )
 
       // Test setting recurrence to NULL
-      const res3 = await adminClient.events.updateV2(eventId, {
+      const res3 = await adminClient.events.update(eventId, {
         recurrence: null,
       })
 
       expect(res3.event.recurrence).toBeNull()
     })
 
-    it('should handle recurring event fields with v2 endpoint', async () => {
+    it('should handle recurring event fields', async () => {
       const recurringEventId = crypto.randomUUID()
       const recurringEventId2 = crypto.randomUUID()
 
@@ -566,7 +566,7 @@ describe('CalendarEvent API', () => {
       const eventId = res.event.id
 
       // Test updating recurring event fields
-      const res2 = await adminClient.events.updateV2(eventId, {
+      const res2 = await adminClient.events.update(eventId, {
         recurringEventId: recurringEventId2,
         originalStartTime: new Date(600),
       })
@@ -575,7 +575,7 @@ describe('CalendarEvent API', () => {
       expect(res2.event.originalStartTime).toEqual(new Date(600))
 
       // Test setting to NULL
-      const res3 = await adminClient.events.updateV2(eventId, {
+      const res3 = await adminClient.events.update(eventId, {
         recurringEventId: null,
         originalStartTime: null,
       })
@@ -584,7 +584,7 @@ describe('CalendarEvent API', () => {
       expect(res3.event.originalStartTime).toBeNull()
     })
 
-    it('should preserve existing values when fields are not provided in v2 update', async () => {
+    it('should preserve existing values when fields are not provided in update', async () => {
       const recurringEventId = crypto.randomUUID()
       const res = await adminClient.events.create(userId, {
         calendarId,
@@ -613,7 +613,7 @@ describe('CalendarEvent API', () => {
       const eventId = res.event.id
 
       // Update only one field
-      const res2 = await adminClient.events.updateV2(eventId, {
+      const res2 = await adminClient.events.update(eventId, {
         title: 'only title updated',
       })
 

--- a/crates/api/src/event/mod.rs
+++ b/crates/api/src/event/mod.rs
@@ -74,12 +74,6 @@ pub fn configure_routes() -> OpenApiRouter {
                 auth::account_can_modify_event_middleware,
             )),
         )
-        .route(
-            "/user/events_v2/{event_id}",
-            patch(update_event_admin_controller).layer(axum::middleware::from_fn(
-                auth::account_can_modify_event_middleware,
-            )),
-        )
         // Delete an event by uid (admin route)
         .route(
             "/user/events/{event_id}",
@@ -110,7 +104,6 @@ pub fn configure_routes() -> OpenApiRouter {
         .route("/events/{event_id}", get(get_event_controller))
         // Update an event by uid
         .route("/events/{event_id}", patch(update_event_controller))
-        .route("/events_v2/{event_id}", patch(update_event_controller))
         // Delete an event by uid
         .route("/events/{event_id}", delete(delete_event_controller))
         // Get event instances


### PR DESCRIPTION
### Changed
- [Breaking Change] Remove "update event V2" endpoint, as it's not supported by the original update event 