### PR TITLE
fix(recurring until): don't change recurring until and include last instance

### DIFF
--- a/clients/javascript/tests/calendarEvent.spec.ts
+++ b/clients/javascript/tests/calendarEvent.spec.ts
@@ -281,7 +281,7 @@ describe('CalendarEvent API', () => {
       expect(resEventTokyo.event).toBeDefined()
       expect(resEventTokyo.event.calendarId).toBe(calendarTokyoId)
       expect(resEventTokyo.event.recurringUntil).toEqual(
-        dayjs('2024-12-12T15:29:59.000Z').toDate() // 30 minutes after until
+        dayjs('2024-12-12T14:59:59.000Z').toDate()
       )
       expect(resEventTokyo.event.recurrence).toEqual(
         expect.objectContaining({
@@ -528,11 +528,13 @@ describe('CalendarEvent API', () => {
       const eventId = res.event.id
 
       // Test updating recurrence
+      const until = new Date(3000).toISOString()
       const res2 = await adminClient.events.update(eventId, {
         recurrence: {
           freq: 'weekly',
           interval: 2,
           count: 10,
+          until: until,
         },
       })
 
@@ -543,6 +545,8 @@ describe('CalendarEvent API', () => {
           count: 10,
         })
       )
+      expect(dayjs(res2.event.recurrence?.until)).toEqual(dayjs(until))
+      expect(res2.event.recurringUntil).toEqual(dayjs(until).toDate())
 
       // Test setting recurrence to NULL
       const res3 = await adminClient.events.update(eventId, {
@@ -550,6 +554,7 @@ describe('CalendarEvent API', () => {
       })
 
       expect(res3.event.recurrence).toBeNull()
+      expect(res3.event.recurringUntil).toBeNull()
     })
 
     it('should handle recurring event fields', async () => {

--- a/crates/api/src/event/update_event.rs
+++ b/crates/api/src/event/update_event.rs
@@ -321,6 +321,7 @@ impl UseCase for UpdateEventUseCase {
             } else {
                 // Set to NULL
                 e.recurrence = None;
+                e.recurring_until = None;
                 true
             }
         // Otherwise, we we don't have a new recurrence, but we have an existing one
@@ -336,6 +337,7 @@ impl UseCase for UpdateEventUseCase {
                     })?
             } else {
                 e.recurrence = None;
+                e.recurring_until = None;
                 true
             }
         } else {

--- a/crates/domain/src/event.rs
+++ b/crates/domain/src/event.rs
@@ -169,10 +169,7 @@ impl CalendarEvent {
             return Ok(false);
         }
 
-        // Add duration to until if it is set
-        self.recurring_until = recurrence
-            .until
-            .map(|until| until + TimeDelta::milliseconds(self.duration));
+        self.recurring_until = recurrence.until;
 
         // Set the recurrence
         self.recurrence = Some(recurrence);

--- a/crates/infra/.sqlx/query-250856069a28f5dee536a708622b2fe03661a19ae98b1cc43fc0a320b02add79.json
+++ b/crates/infra/.sqlx/query-250856069a28f5dee536a708622b2fe03661a19ae98b1cc43fc0a320b02add79.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                    SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n                    WHERE e.calendar_uid  = any($1::uuid[])\n                    AND (\n                        (e.start_time < $2 AND e.end_time > $3)\n                        OR\n                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until > $3))\n                    )\n                    AND busy = true\n                    AND status = any($4::text[])\n                    ",
+  "query": "\n                    SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n                    WHERE e.calendar_uid  = any($1::uuid[])\n                    AND (\n                        (e.start_time <= $2 AND e.end_time >= $3)\n                        OR \n                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until >= $3))\n                    )\n                    ",
   "describe": {
     "columns": [
       {
@@ -138,8 +138,7 @@
       "Left": [
         "UuidArray",
         "Timestamptz",
-        "Timestamptz",
-        "TextArray"
+        "Timestamptz"
       ]
     },
     "nullable": [
@@ -171,5 +170,5 @@
       false
     ]
   },
-  "hash": "7bd47c5ffc7a88798087e8c535e68b38243670a2e691fdcc795552f6cfac9025"
+  "hash": "250856069a28f5dee536a708622b2fe03661a19ae98b1cc43fc0a320b02add79"
 }

--- a/crates/infra/.sqlx/query-6308a907be08687565bfff2d1264832f711a039b89681e4b874adf008ac27a84.json
+++ b/crates/infra/.sqlx/query-6308a907be08687565bfff2d1264832f711a039b89681e4b874adf008ac27a84.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                    SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n                    WHERE e.calendar_uid  = any($1::uuid[])\n                    AND (\n                        (e.start_time <= $2 AND e.end_time >= $3)\n                        OR \n                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until > $3))\n                    )\n                    ",
+  "query": "\n                    SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n                    WHERE e.calendar_uid = $1\n                    AND (\n                        (e.start_time <= $2 AND e.end_time >= $3)\n                        OR\n                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until >= $3))\n                    )\n                    ",
   "describe": {
     "columns": [
       {
@@ -136,7 +136,7 @@
     ],
     "parameters": {
       "Left": [
-        "UuidArray",
+        "Uuid",
         "Timestamptz",
         "Timestamptz"
       ]
@@ -170,5 +170,5 @@
       false
     ]
   },
-  "hash": "12e4cb314134f5167c2b5bfc3b42c90494a1dd89813b0dd9b0e858ffdcec8083"
+  "hash": "6308a907be08687565bfff2d1264832f711a039b89681e4b874adf008ac27a84"
 }

--- a/crates/infra/.sqlx/query-fa89eaf94b8cdaf29179f5c2debac490cef3661dfd8f0fef08f15450b709e631.json
+++ b/crates/infra/.sqlx/query-fa89eaf94b8cdaf29179f5c2debac490cef3661dfd8f0fef08f15450b709e631.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                    SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n                    WHERE e.calendar_uid = $1\n                    AND (\n                        (e.start_time <= $2 AND e.end_time >= $3)\n                        OR\n                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until > $3))\n                    )\n                    ",
+  "query": "\n                    SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n                    WHERE e.calendar_uid  = any($1::uuid[])\n                    AND (\n                        (e.start_time < $2 AND e.end_time > $3)\n                        OR\n                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until >= $3))\n                    )\n                    AND busy = true\n                    AND status = any($4::text[])\n                    ",
   "describe": {
     "columns": [
       {
@@ -136,9 +136,10 @@
     ],
     "parameters": {
       "Left": [
-        "Uuid",
+        "UuidArray",
         "Timestamptz",
-        "Timestamptz"
+        "Timestamptz",
+        "TextArray"
       ]
     },
     "nullable": [
@@ -170,5 +171,5 @@
       false
     ]
   },
-  "hash": "ac33a78c2d15f32199209b7e480ebce5aee0e4c783f021078e2160def3d7e746"
+  "hash": "fa89eaf94b8cdaf29179f5c2debac490cef3661dfd8f0fef08f15450b709e631"
 }

--- a/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -617,7 +617,7 @@ impl IEventRepo for PostgresEventRepo {
                     AND (
                         (e.start_time <= $2 AND e.end_time >= $3)
                         OR
-                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until > $3))
+                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until >= $3))
                     )
                     "#,
                 calendar_id.as_ref(),
@@ -680,7 +680,7 @@ impl IEventRepo for PostgresEventRepo {
                     AND (
                         (e.start_time <= $2 AND e.end_time >= $3)
                         OR 
-                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until > $3))
+                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until >= $3))
                     )
                     "#,
             &calendar_ids as &[Uuid],
@@ -852,7 +852,7 @@ impl IEventRepo for PostgresEventRepo {
                     AND (
                         (e.start_time < $2 AND e.end_time > $3)
                         OR
-                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until > $3))
+                        (e.start_time < $2 AND e.recurrence_jsonb IS NOT NULL AND (e.recurring_until IS NULL OR e.recurring_until >= $3))
                     )
                     AND busy = true
                     AND status = any($4::text[])


### PR DESCRIPTION
### Changed
- Fix `recurring_until` not reset when `recurring` is reset
- Fix `recurring_until` modified when it's set - better to keep the value we receive, and instead do the following ⬇️ 
  - (original change: https://github.com/meetsmore/nittei/pull/290)
- Fix `recurring_until` not being inclusive for all queries
  - If a recurring event has a `recurring_until` that goes until the start of the timespan we are searching (e.g. we are searching from 07/20 00:00 to 07/27 00:00, and the recurring event is everyday at 00:00 for 1h with a `recurring_until` at `07/20 00:00`, then we should include the recurring event as the last instance `07/20 00:00` => `07/20 01:00` should be generated)
  - https://datatracker.ietf.org/doc/html/rfc5545 ("The UNTIL rule part defines a DATE or DATE-TIME value that bounds
      the recurrence rule in an inclusive manner.")


Edit: this doesn't work as, if we are searching from 07/20 00:30 to 07/27 00:30, we are missing the recurring event, even though there are 30minutes still impacting our time range...