### PR TITLE
fix: make query on exceptions during timespan more inclusive

### DIFF
--- a/crates/infra/.sqlx/query-2640e941531679aaf3d7e3de525c84a46bb93521b8a4d139a2c1528e56c96119.json
+++ b/crates/infra/.sqlx/query-2640e941531679aaf3d7e3de525c84a46bb93521b8a4d139a2c1528e56c96119.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n            WHERE e.recurring_event_uid = ANY($1::uuid[]) AND\n                (\n                    (e.original_start_time >= $2 AND e.original_start_time <= $3)\n                    OR\n                    (e.start_time >= $2 AND e.start_time <= $3)\n                )\n            ",
+  "query": "\n            SELECT event_uid, calendar_uid, user_uid, account_uid, external_parent_id, external_id, title, description, event_type, location, all_day, status, start_time, duration, busy, end_time, created, updated, recurrence_jsonb, recurring_until, exdates, recurring_event_uid, original_start_time, reminders_jsonb, service_uid, metadata FROM calendar_events AS e\n            WHERE e.recurring_event_uid = ANY($1::uuid[]) AND\n                (\n                    (e.original_start_time >= $2 AND e.original_start_time <= $3)\n                    OR\n                    (e.start_time <= $3 AND e.end_time >= $2)\n                )\n            ",
   "describe": {
     "columns": [
       {
@@ -170,5 +170,5 @@
       false
     ]
   },
-  "hash": "b01c514da6037175c6d6c4c0c2ffedd0b23035fabf4b8c4900c187880ad44e7e"
+  "hash": "2640e941531679aaf3d7e3de525c84a46bb93521b8a4d139a2c1528e56c96119"
 }

--- a/crates/infra/src/repos/event/calendar_event/postgres.rs
+++ b/crates/infra/src/repos/event/calendar_event/postgres.rs
@@ -462,7 +462,7 @@ impl IEventRepo for PostgresEventRepo {
                 (
                     (e.original_start_time >= $2 AND e.original_start_time <= $3)
                     OR
-                    (e.start_time >= $2 AND e.start_time <= $3)
+                    (e.start_time <= $3 AND e.end_time >= $2)
                 )
             "#,
             &recurring_event_ids as &[Uuid],


### PR DESCRIPTION
### Changed
- Adapted query for getting exceptions of recurring events, so that it's more inclusive
  - Matches other queries like [this one](https://github.com/meetsmore/nittei/blob/4a0833fc2365b3bc28ae27b2d5590b0e732347f6/crates/infra/src/repos/event/calendar_event/postgres.rs#L795)