### PR TITLE
refactor(js client): avoid allocating new arrays when converting to dates

### DIFF
--- a/clients/javascript/lib/accountClient.ts
+++ b/clients/javascript/lib/accountClient.ts
@@ -7,7 +7,7 @@ import type { AccountResponse } from './gen_types/AccountResponse'
 import type { AddAccountIntegrationRequestBody } from './gen_types/AddAccountIntegrationRequestBody'
 import type { CreateAccountRequestBody } from './gen_types/CreateAccountRequestBody'
 import type { CreateAccountResponseBody } from './gen_types/CreateAccountResponseBody'
-import { convertEventDates } from './helpers/datesConverters'
+import { replaceEventStringsToDates } from './helpers/datesConverters'
 
 const ACCOUNT_SEARCH_EVENTS_ENDPOINT = '/account/events/search'
 
@@ -92,8 +92,10 @@ export class NitteiAccountClient extends NitteiBaseClient {
       params
     )
 
-    return {
-      events: res.events.map(convertEventDates),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event)
     }
+
+    return res
   }
 }

--- a/clients/javascript/lib/calendarClient.ts
+++ b/clients/javascript/lib/calendarClient.ts
@@ -15,8 +15,8 @@ import type { OutlookCalendarAccessRole } from './gen_types/OutlookCalendarAcces
 import type { RemoveSyncCalendarPathParams } from './gen_types/RemoveSyncCalendarPathParams'
 import type { RemoveSyncCalendarRequestBody } from './gen_types/RemoveSyncCalendarRequestBody'
 import {
-  convertEventDates,
-  convertInstanceDates,
+  replaceEventStringsToDates,
+  replaceInstanceStringsToDates,
 } from './helpers/datesConverters'
 
 /**
@@ -173,13 +173,14 @@ export class NitteiCalendarClient extends NitteiBaseClient {
       }
     )
 
-    return {
-      calendar: res.calendar,
-      events: res.events?.map(event => ({
-        event: convertEventDates(event.event),
-        instances: event.instances?.map(convertInstanceDates),
-      })),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event.event)
+      for (const instance of event.instances) {
+        replaceInstanceStringsToDates(instance)
+      }
     }
+
+    return res
   }
 
   /**
@@ -311,12 +312,13 @@ export class NitteiCalendarUserClient extends NitteiBaseClient {
       }
     )
 
-    return {
-      calendar: res.calendar,
-      events: res.events.map(event => ({
-        event: convertEventDates(event.event),
-        instances: event.instances.map(convertInstanceDates),
-      })),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event.event)
+      for (const instance of event.instances) {
+        replaceInstanceStringsToDates(instance)
+      }
     }
+
+    return res
   }
 }

--- a/clients/javascript/lib/eventClient.ts
+++ b/clients/javascript/lib/eventClient.ts
@@ -16,8 +16,8 @@ import type { GetEventInstancesAPIResponse } from './gen_types/GetEventInstances
 import type { ID } from './gen_types/ID'
 import type { UpdateEventRequestBody } from './gen_types/UpdateEventRequestBody'
 import {
-  convertEventDates,
-  convertInstanceDates,
+  replaceEventStringsToDates,
+  replaceInstanceStringsToDates,
 } from './helpers/datesConverters'
 
 /**
@@ -49,10 +49,9 @@ export class NitteiEventClient extends NitteiBaseClient {
       `/user/events/${eventId}`,
       data
     )
+    replaceEventStringsToDates(res.event)
 
-    return {
-      event: convertEventDates(res.event),
-    }
+    return res
   }
 
   /**
@@ -70,9 +69,9 @@ export class NitteiEventClient extends NitteiBaseClient {
       data
     )
 
-    return {
-      event: convertEventDates(res.event),
-    }
+    replaceEventStringsToDates(res.event)
+
+    return res
   }
 
   /**
@@ -91,9 +90,11 @@ export class NitteiEventClient extends NitteiBaseClient {
       data
     )
 
-    return {
-      events: res.events.map(convertEventDates),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event)
     }
+
+    return res
   }
 
   /**
@@ -104,9 +105,9 @@ export class NitteiEventClient extends NitteiBaseClient {
   public async getById(eventId: ID): Promise<CalendarEventResponse> {
     const res = await this.get<CalendarEventResponse>(`/user/events/${eventId}`)
 
-    return {
-      event: convertEventDates(res.event),
-    }
+    replaceEventStringsToDates(res.event)
+
+    return res
   }
 
   /**
@@ -123,9 +124,11 @@ export class NitteiEventClient extends NitteiBaseClient {
       `/user/events/external_id/${externalId}`
     )
 
-    return {
-      events: res.events.map(convertEventDates),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event)
     }
+
+    return res
   }
 
   /**
@@ -142,9 +145,11 @@ export class NitteiEventClient extends NitteiBaseClient {
       options
     )
 
-    return {
-      events: res.events.map(convertEventDates),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event)
     }
+
+    return res
   }
 
   /**
@@ -162,12 +167,14 @@ export class NitteiEventClient extends NitteiBaseClient {
       body
     )
 
-    return {
-      events: res.events.map(e => ({
-        event: convertEventDates(e.event),
-        instances: e.instances.map(convertInstanceDates),
-      })),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event.event)
+      for (const instance of event.instances) {
+        replaceInstanceStringsToDates(instance)
+      }
     }
+
+    return res
   }
 
   public async findByMeta(
@@ -185,9 +192,11 @@ export class NitteiEventClient extends NitteiBaseClient {
       value: meta.value,
     })
 
-    return {
-      events: res.events.map(convertEventDates),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event)
     }
+
+    return res
   }
 
   public async remove(eventId: ID) {
@@ -216,10 +225,12 @@ export class NitteiEventClient extends NitteiBaseClient {
       }
     )
 
-    return {
-      event: convertEventDates(res.event),
-      instances: res.instances.map(convertInstanceDates),
+    replaceEventStringsToDates(res.event)
+    for (const instance of res.instances) {
+      replaceInstanceStringsToDates(instance)
     }
+
+    return res
   }
 }
 
@@ -243,9 +254,9 @@ export class NitteiEventUserClient extends NitteiBaseClient {
       data
     )
 
-    return {
-      event: convertEventDates(res.event),
-    }
+    replaceEventStringsToDates(res.event)
+
+    return res
   }
 
   /**
@@ -263,9 +274,9 @@ export class NitteiEventUserClient extends NitteiBaseClient {
       data
     )
 
-    return {
-      event: convertEventDates(res.event),
-    }
+    replaceEventStringsToDates(res.event)
+
+    return res
   }
 
   public async create(
@@ -273,17 +284,17 @@ export class NitteiEventUserClient extends NitteiBaseClient {
   ): Promise<CalendarEventResponse> {
     const res = await this.post<CalendarEventResponse>('/events', data)
 
-    return {
-      event: convertEventDates(res.event),
-    }
+    replaceEventStringsToDates(res.event)
+
+    return res
   }
 
   public async findById(eventId: ID): Promise<CalendarEventResponse> {
     const res = await this.get<CalendarEventResponse>(`/events/${eventId}`)
 
-    return {
-      event: convertEventDates(res.event),
-    }
+    replaceEventStringsToDates(res.event)
+
+    return res
   }
 
   public async remove(eventId: ID) {
@@ -302,9 +313,11 @@ export class NitteiEventUserClient extends NitteiBaseClient {
       }
     )
 
-    return {
-      event: convertEventDates(res.event),
-      instances: res.instances.map(convertInstanceDates),
+    replaceEventStringsToDates(res.event)
+    for (const instance of res.instances) {
+      replaceInstanceStringsToDates(instance)
     }
+
+    return res
   }
 }

--- a/clients/javascript/lib/helpers/datesConverters.ts
+++ b/clients/javascript/lib/helpers/datesConverters.ts
@@ -2,42 +2,37 @@ import type { CalendarEventDTO } from '../gen_types/CalendarEventDTO'
 import type { EventInstance } from '../gen_types/EventInstance'
 
 /**
- * Convert the dates inside an event to Date objects
- * @param event - event to convert
- * @returns event with dates converted to Date objects
+ * Change in place the dates inside an event to Date objects
+ * @param event - event to change in place
+ * @returns nothing
  */
-export function convertEventDates(event: CalendarEventDTO): CalendarEventDTO {
+export function replaceEventStringsToDates(event: CalendarEventDTO): void {
   if (!event) {
-    return event
+    return
   }
-  return {
-    ...event,
-    startTime: new Date(event.startTime),
-    endTime: new Date(event.endTime),
-    created: new Date(event.created),
-    updated: new Date(event.updated),
-    originalStartTime: event.originalStartTime
-      ? new Date(event.originalStartTime)
-      : event.originalStartTime,
-    recurringUntil: event.recurringUntil
-      ? new Date(event.recurringUntil)
-      : event.recurringUntil,
-    exdates: event.exdates?.map(date => new Date(date)),
-  }
+
+  event.startTime = new Date(event.startTime)
+  event.endTime = new Date(event.endTime)
+  event.created = new Date(event.created)
+  event.updated = new Date(event.updated)
+  event.originalStartTime = event.originalStartTime
+    ? new Date(event.originalStartTime)
+    : event.originalStartTime
+  event.recurringUntil = event.recurringUntil
+    ? new Date(event.recurringUntil)
+    : event.recurringUntil
+  event.exdates = event.exdates?.map(date => new Date(date))
 }
 
 /**
- * Convert the dates inside an instance to Date objects
- * @param instance - instance to convert
- * @returns instance with dates converted to Date objects
+ * Change in place the dates inside an instance to Date objects
+ * @param instance - instance to change in place
+ * @returns nothing
  */
-export function convertInstanceDates(instance: EventInstance): EventInstance {
+export function replaceInstanceStringsToDates(instance: EventInstance): void {
   if (!instance) {
-    return instance
+    return
   }
-  return {
-    ...instance,
-    startTime: new Date(instance.startTime),
-    endTime: new Date(instance.endTime),
-  }
+  instance.startTime = new Date(instance.startTime)
+  instance.endTime = new Date(instance.endTime)
 }

--- a/clients/javascript/lib/userClient.ts
+++ b/clients/javascript/lib/userClient.ts
@@ -12,8 +12,8 @@ import type { UpdateUserRequestBody } from './gen_types/UpdateUserRequestBody'
 import type { UserDTO } from './gen_types/UserDTO'
 import type { UserResponse } from './gen_types/UserResponse'
 import {
-  convertEventDates,
-  convertInstanceDates,
+  replaceEventStringsToDates,
+  replaceInstanceStringsToDates,
 } from './helpers/datesConverters'
 
 /**
@@ -109,14 +109,14 @@ export class NitteiUserClient extends NitteiBaseClient {
       }
     )
 
-    return {
-      events: res.events.map(event => {
-        return {
-          event: convertEventDates(event.event),
-          instances: event.instances.map(convertInstanceDates),
-        }
-      }),
+    for (const event of res.events) {
+      replaceEventStringsToDates(event.event)
+      for (const instance of event.instances) {
+        replaceInstanceStringsToDates(instance)
+      }
     }
+
+    return res
   }
 
   /**
@@ -138,10 +138,11 @@ export class NitteiUserClient extends NitteiBaseClient {
       }
     )
 
-    return {
-      userId: res.userId,
-      busy: res.busy.map(convertInstanceDates),
+    for (const instance of res.busy) {
+      replaceInstanceStringsToDates(instance)
     }
+
+    return res
   }
 
   /**
@@ -162,7 +163,10 @@ export class NitteiUserClient extends NitteiBaseClient {
       if (!res?.[key]) {
         return acc
       }
-      acc[key] = res[key].map(convertInstanceDates)
+      for (const instance of res[key]) {
+        replaceInstanceStringsToDates(instance)
+      }
+      acc[key] = res[key]
       return acc
     }, {} as MultipleFreeBusyAPIResponse)
   }


### PR DESCRIPTION
### Changed
- Adapted code so that we avoid re-allocating arrays when converting datestrings to proper dates