### PR TITLE
fix(schedule): Date rules silently ignored due to zero-padding mismatch in Day::Display

### DIFF
--- a/crates/domain/src/schedule.rs
+++ b/crates/domain/src/schedule.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::{
-    CompatibleInstances, Meta, date,
+    CompatibleInstances,
+    Meta,
+    date,
     event_instance::EventInstance,
     shared::entity::{Entity, ID},
     timespan::TimeSpan,

--- a/crates/domain/src/schedule.rs
+++ b/crates/domain/src/schedule.rs
@@ -6,9 +6,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::{
-    CompatibleInstances,
-    Meta,
-    date,
+    CompatibleInstances, Meta, date,
     event_instance::EventInstance,
     shared::entity::{Entity, ID},
     timespan::TimeSpan,
@@ -337,7 +335,7 @@ impl Day {
 
 impl std::fmt::Display for Day {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}-{}-{}", self.year, self.month, self.day)
+        write!(f, "{}-{:02}-{:02}", self.year, self.month, self.day)
     }
 }
 
@@ -366,8 +364,14 @@ impl Schedule {
         let mut weekday_lookup = HashMap::new();
         for rule in &self.rules {
             match &rule.variant {
-                ScheduleRuleVariant::Date(date) => {
-                    date_lookup.insert(date, &rule.intervals);
+                ScheduleRuleVariant::Date(datestr) => {
+                    // Normalize the date string so lookup always matches
+                    // regardless of zero-padding (e.g. "2026-4-2" vs "2026-04-02")
+                    let normalized = match datestr.parse::<Day>() {
+                        Ok(day) => day.to_string(),
+                        Err(_) => datestr.clone(),
+                    };
+                    date_lookup.insert(normalized, &rule.intervals);
                 }
                 ScheduleRuleVariant::WDay(wkay) => {
                     weekday_lookup.insert(wkay, &rule.intervals);
@@ -503,7 +507,7 @@ mod test {
                     }],
                 },
                 ScheduleRule {
-                    variant: ScheduleRuleVariant::Date("1970-1-12".into()),
+                    variant: ScheduleRuleVariant::Date("1970-01-12".into()),
                     intervals: vec![ScheduleRuleInterval {
                         start: Time {
                             hours: 9,


### PR DESCRIPTION
Bug description**

Date-variant `ScheduleRule`s set via the API are silently ignored during `Schedule::freebusy`, causing the schedule to fall back to the matching `WDay` rule as if no date override existed.

**Root cause**

`Schedule::freebusy` builds a `date_lookup` HashMap using the raw string value stored inside the `ScheduleRuleVariant::Date` variant (e.g. `"2026-04-02"`), then looks up each day using `day_cursor.to_string()`. The `Day::Display` implementation formats without zero-padding:

```/dev/null/example.rs#L1-3
// Day { year: 2026, month: 4, day: 2 }.to_string() → "2026-4-2"
// but the rule stored via the API contains → "2026-04-02"
// HashMap lookup: "2026-4-2" != "2026-04-02" → no match → WDay fallback
```

Any client that sends ISO-8601 dates (which is the standard and what the TypeScript client does) will silently get no date override applied. This includes both blocking dates (`intervals: []`) and date-specific custom hours.

**Fix**

Two minimal changes:

1. **`Day::Display`** — zero-pad month and day to produce ISO-8601 compatible strings, making the format consistent everywhere:

```/dev/null/fix1.rs#L1-3
// Before: write!(f, "{}-{}-{}", self.year, self.month, self.day)
// After:
write!(f, "{}-{:02}-{:02}", self.year, self.month, self.day)
```

2. **`Schedule::freebusy`** — normalize date keys through `Day`'s parser before inserting into `date_lookup`, so lookups are robust regardless of the input format:

```/dev/null/fix2.rs#L1-7
ScheduleRuleVariant::Date(datestr) => {
    let normalized = match datestr.parse::<Day>() {
        Ok(day) => day.to_string(),
        Err(_) => datestr.clone(),
    };
    date_lookup.insert(normalized, &rule.intervals);
}
```

Fix 2 makes the lookup defensive against any future format variation. Fix 1 ensures the canonical output of `Day` is proper ISO-8601 from here on.