### PR TITLE
fix: downgrade axios to 1.15.0

### DIFF
--- a/clients/javascript/package.json
+++ b/clients/javascript/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "agentkeepalive": "4.6.0",
-    "axios": "1.15.1",
+    "axios": "1.15.0",
     "axios-retry": "4.5.0",
     "cacheable-lookup": "^6.1.0",
     "dayjs": "1.11.20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,11 +18,11 @@ importers:
         specifier: 4.6.0
         version: 4.6.0
       axios:
-        specifier: 1.15.1
-        version: 1.15.1
+        specifier: 1.15.0
+        version: 1.15.0
       axios-retry:
         specifier: 4.5.0
-        version: 4.5.0(axios@1.15.1)
+        version: 4.5.0(axios@1.15.0)
       cacheable-lookup:
         specifier: ^6.1.0
         version: 6.1.0
@@ -983,8 +983,8 @@ packages:
     peerDependencies:
       axios: 0.x || 1.x
 
-  axios@1.15.1:
-    resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   babel-jest@30.3.0:
     resolution: {integrity: sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==}
@@ -3103,12 +3103,12 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios-retry@4.5.0(axios@1.15.1):
+  axios-retry@4.5.0(axios@1.15.0):
     dependencies:
-      axios: 1.15.1
+      axios: 1.15.0
       is-retry-allowed: 2.2.0
 
-  axios@1.15.1:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5


### PR DESCRIPTION
- Downgrade Axios to 1.15.0 for the time being due to errors polluting logs

```
(node:19) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Socket]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
```