### PR TITLE
feat: update Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -182,15 +182,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -321,6 +321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,10 +351,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -370,21 +388,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -444,6 +456,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -490,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -505,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.22"
+version = "0.15.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
 dependencies = [
  "async-trait",
  "convert_case",
@@ -603,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -669,12 +687,30 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -686,7 +722,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -811,10 +847,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -862,7 +909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -888,16 +935,16 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -910,11 +957,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -982,13 +1029,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1047,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1067,6 +1113,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1195,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1258,9 +1310,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1293,24 +1345,33 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1337,7 +1398,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1346,23 +1416,23 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1404,6 +1474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,11 +1514,9 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1596,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1622,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1632,16 +1709,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1666,27 +1733,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1720,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1743,14 +1815,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -1759,9 +1831,10 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1781,9 +1854,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1792,22 +1865,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
-]
-
-[[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -1830,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -1857,12 +1918,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1943,17 +2004,16 @@ dependencies = [
  "nittei_sdk",
  "nittei_utils",
  "num_cpus",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry-datadog",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "reqwest 0.12.28",
  "serde_json",
  "test-log",
  "tikv-jemallocator",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.33.0",
  "tracing-subscriber",
 ]
 
@@ -1973,10 +2033,10 @@ dependencies = [
  "nittei_domain",
  "nittei_infra",
  "nittei_utils",
- "opentelemetry",
- "opentelemetry-http",
+ "opentelemetry 0.31.0",
+ "opentelemetry-http 0.31.0",
  "prometheus",
- "reqwest 0.13.2",
+ "reqwest",
  "rrule",
  "serde",
  "serde_json",
@@ -1987,7 +2047,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.32.1",
  "utoipa",
  "utoipa-axum",
  "utoipa-swagger-ui",
@@ -2048,7 +2108,7 @@ dependencies = [
  "nittei_domain",
  "nittei_utils",
  "prometheus",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "sqlx",
@@ -2066,7 +2126,7 @@ dependencies = [
  "chrono-tz",
  "nittei_api_structs",
  "nittei_domain",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
 ]
@@ -2118,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2195,20 +2255,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-datadog"
-version = "0.19.0"
+name = "opentelemetry"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6b2d4db32343691eb945e6153e5a4bd494dbf9d931d5bf7d1d7f59bee156d0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-datadog"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4d9a8329def0001b3d9fc4befc13821f96a3c3646be8afb5ed615f65ebf422"
 dependencies = [
  "ahash",
  "http",
  "indexmap 2.14.0",
  "itoa",
- "opentelemetry",
- "opentelemetry-http",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http 0.32.0",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "reqwest 0.12.28",
+ "reqwest",
  "rmp",
  "ryu",
  "thiserror 2.0.18",
@@ -2224,58 +2298,68 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry",
- "reqwest 0.12.28",
+ "opentelemetry 0.31.0",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry 0.32.0",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
- "opentelemetry",
- "opentelemetry-http",
+ "opentelemetry 0.32.0",
+ "opentelemetry-http 0.32.0",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tonic",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "opentelemetry_sdk",
  "prost",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.32.0",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
@@ -2301,7 +2385,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2313,7 +2397,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2340,7 +2424,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2422,7 +2506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2445,18 +2529,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2495,12 +2579,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2803,15 +2881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,55 +2931,15 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
  "h2",
  "http",
  "http-body",
@@ -2947,7 +2976,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3008,7 +3037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3051,7 +3080,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -3082,9 +3111,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3110,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3120,9 +3149,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -3147,9 +3176,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3319,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3364,11 +3393,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3383,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3421,13 +3451,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3438,7 +3468,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3472,7 +3513,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3481,6 +3522,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -3496,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3546,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -3559,12 +3616,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -3574,17 +3632,16 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -3592,14 +3649,14 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3610,78 +3667,63 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
  "sha1",
- "sha2",
- "smallvec",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -3695,18 +3737,16 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3718,13 +3758,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -3734,7 +3775,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -3991,9 +4031,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4084,11 +4124,10 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-trait",
  "base64",
  "bytes",
  "http",
@@ -4103,17 +4142,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
 ]
 
 [[package]]
@@ -4134,9 +4162,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -4146,7 +4174,6 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -4154,6 +4181,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4229,7 +4257,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry",
+ "opentelemetry 0.31.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.32.0",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -4395,9 +4439,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
@@ -4420,9 +4464,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4560,16 +4604,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4580,9 +4618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4590,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4600,9 +4638,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4613,9 +4651,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4656,9 +4694,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4685,15 +4723,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -4703,13 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi-util"
@@ -4781,24 +4806,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4822,36 +4829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4889,18 +4866,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4913,18 +4878,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4934,18 +4887,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4973,18 +4914,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4994,18 +4923,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5021,18 +4938,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5042,18 +4947,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5069,9 +4962,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -5178,9 +5071,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -5232,9 +5125,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -5256,6 +5149,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/bins/nittei/Cargo.toml
+++ b/bins/nittei/Cargo.toml
@@ -40,22 +40,19 @@ tracing-subscriber = { version = "0.3", features = [
     "json",
     "registry",
 ] }
-opentelemetry = { version = "0.31.0", default-features = false, features = [
+opentelemetry = { version = "0.32.0", default-features = false, features = [
     "trace",
 ] }
-opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
-tracing-opentelemetry = "0.32.1"
-opentelemetry-otlp = { version = "0.31.1", features = [
+opentelemetry_sdk = { version = "0.32.0", features = ["rt-tokio"] }
+tracing-opentelemetry = "0.33.0"
+opentelemetry-otlp = { version = "0.32.0", features = [
     "reqwest-client",
     "reqwest-rustls",
     "http-proto",
     "tls",
 ] }
-opentelemetry-datadog = { version = "0.19.0", features = ["reqwest-client"] }
-reqwest = { version = "0.12.28", default-features = false, features = [
-    "http2",
-    "json",
-    "rustls-tls",
+opentelemetry-datadog = { version = "0.20.0", features = [
+    "reqwest-client",
 ] }
 
 chrono = "0.4.39"

--- a/bins/nittei/src/main.rs
+++ b/bins/nittei/src/main.rs
@@ -17,17 +17,6 @@ fn main() {
     // Install the custom panic hook
     nittei::backtrace::install_custom_panic_hook();
 
-    // Initialize the subscriber for logging & tracing
-    let _ = init_subscriber().inspect_err(
-        // Allow eprintln! to be used here as logging/tracing has failed to initialize
-        #[allow(clippy::print_stderr)]
-        |e| {
-            eprintln!("[init_subscriber] Error: {e}");
-            // Exit the process with an error code
-            std::process::exit(1);
-        },
-    );
-
     let runtime_flavor = nittei_utils::config::APP_CONFIG
         .tokio_runtime_flavor
         .as_str();
@@ -78,6 +67,15 @@ fn main() {
 
 /// The main function that will be run by the tokio runtime
 async fn run() -> anyhow::Result<()> {
+    // Initialize the subscriber for logging & tracing
+    // Must be called inside the Tokio runtime: the batch exporter (rt-tokio) spawns
+    // a background task and requires an active runtime at initialization time.
+    init_subscriber().inspect_err(
+        // Allow eprintln! to be used here as logging/tracing has failed to initialize
+        #[allow(clippy::print_stderr)]
+        |e| eprintln!("[init_subscriber] Error: {e}"),
+    )?;
+
     print_runtime_info();
 
     let context = setup_context()

--- a/bins/nittei/src/telemetry.rs
+++ b/bins/nittei/src/telemetry.rs
@@ -1,8 +1,6 @@
-use std::time::Duration;
-
 use opentelemetry::{global, propagation::TextMapCompositePropagator, trace::TracerProvider};
 use opentelemetry_datadog::{ApiVersion, DatadogPipelineBuilder, DatadogPropagator};
-use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
+use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     Resource,
     propagation::TraceContextPropagator,
@@ -137,10 +135,7 @@ fn get_tracer_datadog(
     config.sampler = Box::new(get_sampler());
     config.id_generator = Box::new(RandomIdGenerator::default());
 
-    let http_client = get_http_client()?;
-
     DatadogPipelineBuilder::default()
-        .with_http_client(http_client)
         .with_service_name(service_name)
         .with_version(service_version)
         .with_env(service_env)
@@ -159,11 +154,9 @@ fn get_tracer_otlp(
     service_version: String,
     service_env: String,
 ) -> anyhow::Result<SdkTracerProvider> {
-    let http_client = get_http_client()?;
     let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_http()
-        .with_http_client(http_client)
-        .with_protocol(opentelemetry_otlp::Protocol::HttpJson)
+        .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
         .with_endpoint(otlp_endpoint)
         .build()?;
 
@@ -204,16 +197,4 @@ fn get_sampler() -> Sampler {
     // (1) parent => so if parent exists always sample
     // (2) if no parent, then the trace id ratio
     Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(ratio_to_sample)))
-}
-
-/// Get the HTTP client to be used
-/// This is used to send traces to the tracing endpoint
-///
-/// The exporter runs on a different thread than the main thread, so we need to use a blocking client.
-fn get_http_client() -> anyhow::Result<reqwest::blocking::Client> {
-    reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .connect_timeout(Duration::from_secs(5))
-        .build()
-        .map_err(|e| anyhow::anyhow!("Failed to create HTTP client for telemetry: {}", e))
 }

--- a/crates/infra/.sqlx/query-12e4cb314134f5167c2b5bfc3b42c90494a1dd89813b0dd9b0e858ffdcec8083.json
+++ b/crates/infra/.sqlx/query-12e4cb314134f5167c2b5bfc3b42c90494a1dd89813b0dd9b0e858ffdcec8083.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-196df86fd298c49d6d7b407fd521abafff09a8731969743bb9f5a26f484b5059.json
+++ b/crates/infra/.sqlx/query-196df86fd298c49d6d7b407fd521abafff09a8731969743bb9f5a26f484b5059.json
@@ -6,37 +6,79 @@
       {
         "ordinal": 0,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "settings",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "settings"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-1b289e060b408882bc8daa6a689268a090de4e2f82b57540a4b3ec8ee1a97dc5.json
+++ b/crates/infra/.sqlx/query-1b289e060b408882bc8daa6a689268a090de4e2f82b57540a4b3ec8ee1a97dc5.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendars",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendars",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "ext_calendar_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendars",
+            "name": "ext_calendar_id"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "provider",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendars",
+            "name": "provider"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-1e438d5dacbdaec4fb616dcbcbb31ae31b4a847cbdaf2b7995103e6f2923da7a.json
+++ b/crates/infra/.sqlx/query-1e438d5dacbdaec4fb616dcbcbb31ae31b4a847cbdaf2b7995103e6f2923da7a.json
@@ -6,32 +6,68 @@
       {
         "ordinal": 0,
         "name": "schedule_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "schedule_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "rules",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "rules"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "timezone",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "timezone"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-2088842430cadf8504c4c71e5592f49176938c0ca5db04d469ea42b2c5d893cd.json
+++ b/crates/infra/.sqlx/query-2088842430cadf8504c4c71e5592f49176938c0ca5db04d469ea42b2c5d893cd.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-2640e941531679aaf3d7e3de525c84a46bb93521b8a4d139a2c1528e56c96119.json
+++ b/crates/infra/.sqlx/query-2640e941531679aaf3d7e3de525c84a46bb93521b8a4d139a2c1528e56c96119.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-273c492047225a990ccd78fa2bf7e937860681b3bd96a206b6ee4995ac04711b.json
+++ b/crates/infra/.sqlx/query-273c492047225a990ccd78fa2bf7e937860681b3bd96a206b6ee4995ac04711b.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "secret_api_key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "secret_api_key"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "public_jwt_key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "public_jwt_key"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "settings",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "settings"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-292a182b383e6b53acc25d11ace7d34114996eb196e4f5759f86fcb75c7ada63.json
+++ b/crates/infra/.sqlx/query-292a182b383e6b53acc25d11ace7d34114996eb196e4f5759f86fcb75c7ada63.json
@@ -6,32 +6,68 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "ext_calendar_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendar_events",
+            "name": "ext_calendar_id"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "ext_calendar_event_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendar_events",
+            "name": "ext_calendar_event_id"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "provider",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "externally_synced_calendar_events",
+            "name": "provider"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "user_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-2bf3e79eb1d11fc83cc0f02150ddb0e10910e65f9c47e6dd1ca37c7f20587a5a.json
+++ b/crates/infra/.sqlx/query-2bf3e79eb1d11fc83cc0f02150ddb0e10910e65f9c47e6dd1ca37c7f20587a5a.json
@@ -6,37 +6,79 @@
       {
         "ordinal": 0,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "settings",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "settings"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-2d95094ca505894b71df11bdb89e0f1cd2ce3f110f52cbecb594cac37d1a99d9.json
+++ b/crates/infra/.sqlx/query-2d95094ca505894b71df11bdb89e0f1cd2ce3f110f52cbecb594cac37d1a99d9.json
@@ -6,32 +6,68 @@
       {
         "ordinal": 0,
         "name": "schedule_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "schedule_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "rules",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "rules"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "timezone",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "timezone"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-34a936c0f2b048420febbc50b15e91ad6b30d517016d197d25d225ef5b96567d.json
+++ b/crates/infra/.sqlx/query-34a936c0f2b048420febbc50b15e91ad6b30d517016d197d25d225ef5b96567d.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "external_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-3630fca38f7591d10e955848a891d31803fd0e727d72fb25ea4fa6293315d74e.json
+++ b/crates/infra/.sqlx/query-3630fca38f7591d10e955848a891d31803fd0e727d72fb25ea4fa6293315d74e.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-386895f60dd59c5a0a56e75c279d632e9709b17760a5250d47031d84a01ad548.json
+++ b/crates/infra/.sqlx/query-386895f60dd59c5a0a56e75c279d632e9709b17760a5250d47031d84a01ad548.json
@@ -6,17 +6,35 @@
       {
         "ordinal": 0,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "service_reservations",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "timestamp",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "service_reservations",
+            "name": "timestamp"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "count",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "service_reservations",
+            "name": "count"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-3a32782ddec2583f61bb3a256c3dc60704728da9f9cb2c7e365da2e825c8959b.json
+++ b/crates/infra/.sqlx/query-3a32782ddec2583f61bb3a256c3dc60704728da9f9cb2c7e365da2e825c8959b.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-3cf744a50527e2a67bb32bc76896f3c4c5a46fe287b775178b5c0fd24b11118c.json
+++ b/crates/infra/.sqlx/query-3cf744a50527e2a67bb32bc76896f3c4c5a46fe287b775178b5c0fd24b11118c.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "external_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-4182f1c0b277e6bae6c3a59a43a6633909b7d13b3b098db1760e7844c269216e.json
+++ b/crates/infra/.sqlx/query-4182f1c0b277e6bae6c3a59a43a6633909b7d13b3b098db1760e7844c269216e.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "multi_person",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "multi_person"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-5102628702efe5c825127f51473de67b9b66eb66ec82d7a79b4c6f1ce1a5664c.json
+++ b/crates/infra/.sqlx/query-5102628702efe5c825127f51473de67b9b66eb66ec82d7a79b4c6f1ce1a5664c.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-52e66ef0d25dd55202e0ed3511698bed5f6b4d61d517530b450cc72fb855e174.json
+++ b/crates/infra/.sqlx/query-52e66ef0d25dd55202e0ed3511698bed5f6b4d61d517530b450cc72fb855e174.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "multi_person",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "multi_person"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-5b0b0183190f420be92016df06c8c6619ed1b841b532f0d9a03f2dd0318b884a.json
+++ b/crates/infra/.sqlx/query-5b0b0183190f420be92016df06c8c6619ed1b841b532f0d9a03f2dd0318b884a.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-5c0179cbe52f7bd2f3a88444984242e14d1a2caccd2099d81ba0e0de66f95112.json
+++ b/crates/infra/.sqlx/query-5c0179cbe52f7bd2f3a88444984242e14d1a2caccd2099d81ba0e0de66f95112.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-6819ea7b153c61a0c859dcb3f2c466c8bdd450b147f7989d32f2e79532c55d1a.json
+++ b/crates/infra/.sqlx/query-6819ea7b153c61a0c859dcb3f2c466c8bdd450b147f7989d32f2e79532c55d1a.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "external_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-6fb8a48d490a58a6eaa77ee4ad5c384d219a9f20204fc712457df8ec887665c6.json
+++ b/crates/infra/.sqlx/query-6fb8a48d490a58a6eaa77ee4ad5c384d219a9f20204fc712457df8ec887665c6.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-743c8927d9e4491ffc27b40fbaa63a77f76f6fca631ac253a0dd30170377f644.json
+++ b/crates/infra/.sqlx/query-743c8927d9e4491ffc27b40fbaa63a77f76f6fca631ac253a0dd30170377f644.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-77455db78470e7adb3b0dff75b274e760ebdf6cf58d6da75940a381180ca0777.json
+++ b/crates/infra/.sqlx/query-77455db78470e7adb3b0dff75b274e760ebdf6cf58d6da75940a381180ca0777.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "reminders",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "reminders",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "remind_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "reminders",
+            "name": "remind_at"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "version",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "reminders",
+            "name": "version"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "identifier",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "reminders",
+            "name": "identifier"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-7bd47c5ffc7a88798087e8c535e68b38243670a2e691fdcc795552f6cfac9025.json
+++ b/crates/infra/.sqlx/query-7bd47c5ffc7a88798087e8c535e68b38243670a2e691fdcc795552f6cfac9025.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-80786f9ca51fd11a4846a2d6281e18ec1772c932e20e9e8ed9a0bb652ed20906.json
+++ b/crates/infra/.sqlx/query-80786f9ca51fd11a4846a2d6281e18ec1772c932e20e9e8ed9a0bb652ed20906.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "event_reminder_versions",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "version",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "event_reminder_versions",
+            "name": "version"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-829465985ac8cd0663f5f5fa791ac0231d793d784c3d65f26ac0fbfc7467455a.json
+++ b/crates/infra/.sqlx/query-829465985ac8cd0663f5f5fa791ac0231d793d784c3d65f26ac0fbfc7467455a.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-879882bf7ae15563580f5a8e735c2073ba6bc4b7e0d2076082bab5607ffa8e4c.json
+++ b/crates/infra/.sqlx/query-879882bf7ae15563580f5a8e735c2073ba6bc4b7e0d2076082bab5607ffa8e4c.json
@@ -6,37 +6,79 @@
       {
         "ordinal": 0,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "settings",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "settings"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-95f1e3614d613f2f22b47e18e44746210df11a3d412d1f54fb5b7aab8da9403e.json
+++ b/crates/infra/.sqlx/query-95f1e3614d613f2f22b47e18e44746210df11a3d412d1f54fb5b7aab8da9403e.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "secret_api_key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "secret_api_key"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "public_jwt_key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "public_jwt_key"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "settings",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "settings"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-968fca0a646464c9e5fc5400764499a47bd4af9bb4ee0d0b09555e3e8fec1ce2.json
+++ b/crates/infra/.sqlx/query-968fca0a646464c9e5fc5400764499a47bd4af9bb4ee0d0b09555e3e8fec1ce2.json
@@ -6,17 +6,35 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_event_reminder_generation_jobs",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "timestamp",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_event_reminder_generation_jobs",
+            "name": "timestamp"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "version",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_event_reminder_generation_jobs",
+            "name": "version"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-99a8b77cb53ac1f8c9181744ec934247a749ee93707cd136abe9e33aac51f555.json
+++ b/crates/infra/.sqlx/query-99a8b77cb53ac1f8c9181744ec934247a749ee93707cd136abe9e33aac51f555.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "external_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-9a4bd7a94f17e7e577f8fcfce8106d99c902d1aac7e7bfd8bb37d24bed6890e9.json
+++ b/crates/infra/.sqlx/query-9a4bd7a94f17e7e577f8fcfce8106d99c902d1aac7e7bfd8bb37d24bed6890e9.json
@@ -6,37 +6,79 @@
       {
         "ordinal": 0,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "settings",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "settings"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-9ce8fe431391490e1ef5d664edab166432645719105e17f108a918c73e48c652.json
+++ b/crates/infra/.sqlx/query-9ce8fe431391490e1ef5d664edab166432645719105e17f108a918c73e48c652.json
@@ -6,32 +6,68 @@
       {
         "ordinal": 0,
         "name": "schedule_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "schedule_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "rules",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "rules"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "timezone",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "timezone"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-a0de3aebf02766d0d00717faa9ce79e9e561e0aebe247b8678955162aaa0bbb0.json
+++ b/crates/infra/.sqlx/query-a0de3aebf02766d0d00717faa9ce79e9e561e0aebe247b8678955162aaa0bbb0.json
@@ -6,27 +6,52 @@
       {
         "ordinal": 0,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "multi_person",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "multi_person"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "services",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "users",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-a233ecc6723d546776dcebcfb11c45f735ba8644062aeebf0848ebe24372353c.json
+++ b/crates/infra/.sqlx/query-a233ecc6723d546776dcebcfb11c45f735ba8644062aeebf0848ebe24372353c.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "schedule_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "schedule_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "rules",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "rules"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "timezone",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "timezone"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-a44333a52c7262353a57ddb58d99fde9ee7db2479abc0f43e4deaa0e5ad3362a.json
+++ b/crates/infra/.sqlx/query-a44333a52c7262353a57ddb58d99fde9ee7db2479abc0f43e4deaa0e5ad3362a.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "event_reminder_versions",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "version",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "event_reminder_versions",
+            "name": "version"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-ab3f370879ccda6e5533e707897ccc68a0f5a5ca62afa0e4ef6546fc2da90085.json
+++ b/crates/infra/.sqlx/query-ab3f370879ccda6e5533e707897ccc68a0f5a5ca62afa0e4ef6546fc2da90085.json
@@ -6,32 +6,68 @@
       {
         "ordinal": 0,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "user_integrations",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "user_integrations",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "refresh_token",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "user_integrations",
+            "name": "refresh_token"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "access_token",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "user_integrations",
+            "name": "access_token"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "access_token_expires_ts",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "user_integrations",
+            "name": "access_token_expires_ts"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "provider",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "user_integrations",
+            "name": "provider"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-ac33a78c2d15f32199209b7e480ebce5aee0e4c783f021078e2160def3d7e746.json
+++ b/crates/infra/.sqlx/query-ac33a78c2d15f32199209b7e480ebce5aee0e4c783f021078e2160def3d7e746.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-b6cf4fb5085d029b314caf5aca6d857598dce67c3e74f98b7f3b63e3ae9b2f2d.json
+++ b/crates/infra/.sqlx/query-b6cf4fb5085d029b314caf5aca6d857598dce67c3e74f98b7f3b63e3ae9b2f2d.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "secret_api_key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "secret_api_key"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "public_jwt_key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "public_jwt_key"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "settings",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "settings"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-cdb0b0aba2c9f56dac6d9a0a08a8a28d846aab11299b2098f3feb6b3ee7456a9.json
+++ b/crates/infra/.sqlx/query-cdb0b0aba2c9f56dac6d9a0a08a8a28d846aab11299b2098f3feb6b3ee7456a9.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-cf91de43a3232384c037caa95b4e3d9d7e08709fe4dd0f143bcf4c6db1296517.json
+++ b/crates/infra/.sqlx/query-cf91de43a3232384c037caa95b4e3d9d7e08709fe4dd0f143bcf4c6db1296517.json
@@ -6,37 +6,79 @@
       {
         "ordinal": 0,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "settings",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "settings"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-d59f7d88f988149254292ab6faa175a965fe7fa0cc9c45a42160997199c78114.json
+++ b/crates/infra/.sqlx/query-d59f7d88f988149254292ab6faa175a965fe7fa0cc9c45a42160997199c78114.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "account_integrations",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "client_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "account_integrations",
+            "name": "client_id"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "client_secret",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "account_integrations",
+            "name": "client_secret"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "redirect_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "account_integrations",
+            "name": "redirect_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "provider",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "account_integrations",
+            "name": "provider"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-dae4e8fe37ab9e71be49ccfda4cd101b0be7d470da731625b2da255c4e16fd3a.json
+++ b/crates/infra/.sqlx/query-dae4e8fe37ab9e71be49ccfda4cd101b0be7d470da731625b2da255c4e16fd3a.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "secret_api_key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "secret_api_key"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "public_jwt_key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "public_jwt_key"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "settings",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "accounts",
+            "name": "settings"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-db009061ff49fcdd2b16affb3161768b2f57a94e13fbff4480b29012f1b9d062.json
+++ b/crates/infra/.sqlx/query-db009061ff49fcdd2b16affb3161768b2f57a94e13fbff4480b29012f1b9d062.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "external_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-eb8c849dd74b03336ee21563f429170d057c9fe8f629cc919925d51e4f9c5eb7.json
+++ b/crates/infra/.sqlx/query-eb8c849dd74b03336ee21563f429170d057c9fe8f629cc919925d51e4f9c5eb7.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "external_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-ec968966f4dd77acc01b48a66ab759546588fd3142e5dcea37110d71d43339cc.json
+++ b/crates/infra/.sqlx/query-ec968966f4dd77acc01b48a66ab759546588fd3142e5dcea37110d71d43339cc.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-ecd0aac67216b3d70960e8b6986e6c4aa1e37c821a94695aeba097a1859d8232.json
+++ b/crates/infra/.sqlx/query-ecd0aac67216b3d70960e8b6986e6c4aa1e37c821a94695aeba097a1859d8232.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-ee52678beec167a83f58541bd3b20b825abc9301f0d767488ab170ccb2dec5d6.json
+++ b/crates/infra/.sqlx/query-ee52678beec167a83f58541bd3b20b825abc9301f0d767488ab170ccb2dec5d6.json
@@ -6,37 +6,79 @@
       {
         "ordinal": 0,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "settings",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "settings"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "key",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "key"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendars",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-f2756d349bf7981cc3d54b12f56265e59f64a65c05736fc4dcf68fc7acd2dace.json
+++ b/crates/infra/.sqlx/query-f2756d349bf7981cc3d54b12f56265e59f64a65c05736fc4dcf68fc7acd2dace.json
@@ -6,132 +6,288 @@
       {
         "ordinal": 0,
         "name": "event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "calendar_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "calendar_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "account_uid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "external_parent_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_parent_id"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "external_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "title",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "title"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "event_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "event_type"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "location",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "location"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "all_day",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "all_day"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "status"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "start_time"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "duration",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "duration"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "busy",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "busy"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "end_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "end_time"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "created",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "created"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "updated",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "updated"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "recurrence_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurrence_jsonb"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "recurring_until",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_until"
+          }
+        }
       },
       {
         "ordinal": 20,
         "name": "exdates",
-        "type_info": "TimestamptzArray"
+        "type_info": "TimestamptzArray",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "exdates"
+          }
+        }
       },
       {
         "ordinal": 21,
         "name": "recurring_event_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "recurring_event_uid"
+          }
+        }
       },
       {
         "ordinal": 22,
         "name": "original_start_time",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "original_start_time"
+          }
+        }
       },
       {
         "ordinal": 23,
         "name": "reminders_jsonb",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "reminders_jsonb"
+          }
+        }
       },
       {
         "ordinal": 24,
         "name": "service_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "service_uid"
+          }
+        }
       },
       {
         "ordinal": 25,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "calendar_events",
+            "name": "metadata"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/.sqlx/query-fb82e70ae01f35a2c88c860fae48dfca4fe9c0bb4df09bc6e749ac3a5b33da81.json
+++ b/crates/infra/.sqlx/query-fb82e70ae01f35a2c88c860fae48dfca4fe9c0bb4df09bc6e749ac3a5b33da81.json
@@ -6,32 +6,68 @@
       {
         "ordinal": 0,
         "name": "schedule_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "schedule_uid"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "user_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "user_uid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "rules",
-        "type_info": "Json"
+        "type_info": "Json",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "rules"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "timezone",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "timezone"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "metadata",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "schedules",
+            "name": "metadata"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "account_uid",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "account_uid"
+          }
+        }
       }
     ],
     "parameters": {

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -35,9 +35,9 @@ chrono-tz = { version = "0.10.1", features = ["serde"] }
 uuid = { version = "1.1", features = ["serde"] }
 url = { version = "2.5" }
 
-sqlx = { version = "0.8", features = [
+sqlx = { version = "0.9", features = [
   "runtime-tokio",
-  "tls-rustls-ring",
+  "tls-rustls",
   "postgres",
   "uuid",
   "json",

--- a/crates/infra/src/repos/shared/query_structs.rs
+++ b/crates/infra/src/repos/shared/query_structs.rs
@@ -24,7 +24,7 @@ pub struct MetadataFindQuery {
 ///
 /// This mutates the query_builder !
 pub fn apply_id_query(
-    query_builder: &mut sqlx::QueryBuilder<'_, Postgres>,
+    query_builder: &mut sqlx::QueryBuilder<Postgres>,
     field_name: &str,
     id_query: &Option<IDQuery>,
 ) {
@@ -92,7 +92,7 @@ pub fn apply_id_query(
 ///
 /// This effectively mutates the query_builder !
 pub fn apply_string_query(
-    query_builder: &mut sqlx::QueryBuilder<'_, Postgres>,
+    query_builder: &mut sqlx::QueryBuilder<Postgres>,
     field_name: &str,
     string_query: &Option<StringQuery>,
 ) {
@@ -136,7 +136,7 @@ pub fn apply_string_query(
 ///
 /// This effectively mutates the query_builder !
 pub fn apply_datetime_query(
-    query_builder: &mut sqlx::QueryBuilder<'_, Postgres>,
+    query_builder: &mut sqlx::QueryBuilder<Postgres>,
     field_name: &str,
     datetime_query: &Option<DateTimeQuery>,
     convert_to_millis: bool,


### PR DESCRIPTION
- Update Rust dependencies
- Fix an issue with telemetry setup
  - Move the init call inside the Tokio runtime, allowing to use async HTTP client (via Reqwest)
  - Remove the blocking Reqwest client (both Datadog and OTEL OTLP libs now create their own async HTTP client via features)
- Fix a few lifetimes not need anymore following SQLX update
- Regenerate queries' cache due to SQLX update 