### PR TITLE
refactor: split healthcheck endpoint

### DIFF
--- a/bins/nittei/tests/api.rs
+++ b/bins/nittei/tests/api.rs
@@ -27,9 +27,15 @@ use nittei_sdk::{
 };
 
 #[tokio::test]
-async fn test_status_ok() {
+async fn test_liveness_ok() {
     let (_, sdk, _) = spawn_app().await;
-    assert!(sdk.status.check_health().await.is_ok());
+    assert!(sdk.status.check_liveness().await.is_ok());
+}
+
+#[tokio::test]
+async fn test_readiness_ok() {
+    let (_, sdk, _) = spawn_app().await;
+    assert!(sdk.status.check_readiness().await.is_ok());
 }
 
 #[tokio::test]

--- a/charts/nittei/templates/deployment.yaml
+++ b/charts/nittei/templates/deployment.yaml
@@ -109,6 +109,8 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/charts/nittei/values.yaml
+++ b/charts/nittei/values.yaml
@@ -93,16 +93,29 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
+startupProbe:
+  httpGet:
+    path: /api/v1/healthz/live
+    port: 5000
+  # Allow up to 60s for the app to start (failureThreshold * periodSeconds)
+  # periodSeconds is kept short so k8s detects a successful start with minimal delay
+  failureThreshold: 60
+  periodSeconds: 1
 livenessProbe:
   httpGet:
-    path: /api/v1/healthcheck
+    path: /api/v1/healthz/live
     port: 5000
-  initialDelaySeconds: 2
+  # initialDelaySeconds not needed — startupProbe guards the startup window
+  periodSeconds: 10
+  failureThreshold: 3
 readinessProbe:
   httpGet:
-    path: /api/v1/healthcheck
+    path: /api/v1/healthz/ready
     port: 5000
-  initialDelaySeconds: 2
+  # initialDelaySeconds not needed — startupProbe guards the startup window
+  # Faster than liveness: detect DB unavailability within ~15s (periodSeconds * failureThreshold)
+  periodSeconds: 5
+  failureThreshold: 3
 
 autoscaling:
   enabled: false

--- a/charts/nittei/values.yaml
+++ b/charts/nittei/values.yaml
@@ -43,12 +43,10 @@ podAnnotations: {}
 
 deploymentLabels: {}
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -65,12 +63,10 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    []
+  hosts: []
     # - host: chart-example.local
     #   paths:
     #     - path: /
@@ -80,8 +76,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -95,7 +90,7 @@ resources:
 
 startupProbe:
   httpGet:
-    path: /api/v1/healthz/live
+    path: /api/v1/health/live
     port: 5000
   # Allow up to 60s for the app to start (failureThreshold * periodSeconds)
   # periodSeconds is kept short so k8s detects a successful start with minimal delay
@@ -103,14 +98,14 @@ startupProbe:
   periodSeconds: 1
 livenessProbe:
   httpGet:
-    path: /api/v1/healthz/live
+    path: /api/v1/health/live
     port: 5000
   # initialDelaySeconds not needed — startupProbe guards the startup window
   periodSeconds: 10
   failureThreshold: 3
 readinessProbe:
   httpGet:
-    path: /api/v1/healthz/ready
+    path: /api/v1/health/ready
     port: 5000
   # initialDelaySeconds not needed — startupProbe guards the startup window
   # Faster than liveness: detect DB unavailability within ~15s (periodSeconds * failureThreshold)

--- a/clients/javascript/lib/healthClient.ts
+++ b/clients/javascript/lib/healthClient.ts
@@ -4,7 +4,17 @@ import { NitteiBaseClient } from './baseClient'
  * Client for checking the health of the service
  */
 export class NitteiHealthClient extends NitteiBaseClient {
-  public async checkStatus(): Promise<void> {
-    await this.get<void>('/healthcheck')
+  /**
+   * Liveness probe — checks that the process is running.
+   */
+  public async checkLiveness(): Promise<void> {
+    await this.get<void>('/healthz/live')
+  }
+
+  /**
+   * Readiness probe — checks that the service can handle traffic (DB reachable).
+   */
+  public async checkReadiness(): Promise<void> {
+    await this.get<void>('/healthz/ready')
   }
 }

--- a/clients/javascript/lib/healthClient.ts
+++ b/clients/javascript/lib/healthClient.ts
@@ -8,13 +8,13 @@ export class NitteiHealthClient extends NitteiBaseClient {
    * Liveness probe — checks that the process is running.
    */
   public async checkLiveness(): Promise<void> {
-    await this.get<void>('/healthz/live')
+    await this.get<void>('/health/live')
   }
 
   /**
    * Readiness probe — checks that the service can handle traffic (DB reachable).
    */
   public async checkReadiness(): Promise<void> {
-    await this.get<void>('/healthz/ready')
+    await this.get<void>('/health/ready')
   }
 }

--- a/clients/javascript/tests/health.spec.ts
+++ b/clients/javascript/tests/health.spec.ts
@@ -1,9 +1,15 @@
 import { NitteiClient } from '../lib'
 
 describe('Health API', () => {
-  it('should report healthy status', async () => {
+  it('should report readiness status', async () => {
     const client = await NitteiClient({})
     // Should not throw
-    await client.health.checkStatus()
+    await client.health.checkReadiness()
+  })
+
+  it('should report liveness status', async () => {
+    const client = await NitteiClient({})
+    // Should not throw
+    await client.health.checkLiveness()
   })
 })

--- a/clients/rust/src/status.rs
+++ b/clients/rust/src/status.rs
@@ -15,9 +15,17 @@ impl StatusClient {
         Self { base }
     }
 
-    pub async fn check_health(&self) -> APIResponse<get_service_health::APIResponse> {
+    /// Liveness probe — checks that the process is running.
+    pub async fn check_liveness(&self) -> APIResponse<get_service_health::APIResponse> {
         self.base
-            .get("healthcheck".into(), None, StatusCode::OK)
+            .get("healthz/live".into(), None, StatusCode::OK)
+            .await
+    }
+
+    /// Readiness probe — checks that the service can handle traffic (DB reachable).
+    pub async fn check_readiness(&self) -> APIResponse<get_service_health::APIResponse> {
+        self.base
+            .get("healthz/ready".into(), None, StatusCode::OK)
             .await
     }
 }

--- a/clients/rust/src/status.rs
+++ b/clients/rust/src/status.rs
@@ -18,14 +18,14 @@ impl StatusClient {
     /// Liveness probe — checks that the process is running.
     pub async fn check_liveness(&self) -> APIResponse<get_service_health::APIResponse> {
         self.base
-            .get("healthz/live".into(), None, StatusCode::OK)
+            .get("health/live".into(), None, StatusCode::OK)
             .await
     }
 
     /// Readiness probe — checks that the service can handle traffic (DB reachable).
     pub async fn check_readiness(&self) -> APIResponse<get_service_health::APIResponse> {
         self.base
-            .get("healthz/ready".into(), None, StatusCode::OK)
+            .get("health/ready".into(), None, StatusCode::OK)
             .await
     }
 }

--- a/crates/api/src/status/mod.rs
+++ b/crates/api/src/status/mod.rs
@@ -4,8 +4,24 @@ use nittei_infra::{NitteiContext, metrics::INFRA_REGISTRY};
 use prometheus::TextEncoder;
 use utoipa_axum::router::OpenApiRouter;
 
-/// Get the status of the service
-async fn status(Extension(ctx): Extension<NitteiContext>) -> (StatusCode, Json<APIResponse>) {
+/// Liveness probe — confirms the process is running.
+/// k8s restarts the pod if this returns a non-2xx status.
+/// No external dependency checks: if the process can respond, it is alive.
+async fn liveness() -> (StatusCode, Json<APIResponse>) {
+    (
+        StatusCode::OK,
+        Json(APIResponse {
+            message: "Ok!\r\n".into(),
+        }),
+    )
+}
+
+/// Readiness probe — confirms the service can handle traffic.
+/// k8s removes the pod from the load balancer (but does NOT restart it) when this fails.
+/// Checks DB connectivity so traffic is only routed when dependencies are reachable.
+async fn readiness(
+    Extension(ctx): Extension<NitteiContext>,
+) -> (StatusCode, Json<APIResponse>) {
     match ctx.repos.status.check_connection().await {
         Ok(_) => (
             StatusCode::OK,
@@ -14,11 +30,11 @@ async fn status(Extension(ctx): Extension<NitteiContext>) -> (StatusCode, Json<A
             }),
         ),
         Err(e) => {
-            tracing::error!("[status] Error checking connection: {:?}", e);
+            tracing::error!("[status] Readiness check failed: {:?}", e);
             (
-                StatusCode::INTERNAL_SERVER_ERROR,
+                StatusCode::SERVICE_UNAVAILABLE,
                 Json(APIResponse {
-                    message: "Internal Server Error".into(),
+                    message: "Service Unavailable".into(),
                 }),
             )
         }
@@ -46,7 +62,9 @@ async fn metrics() -> (StatusCode, String) {
 /// Configure the routes for the status module
 pub fn configure_routes() -> OpenApiRouter {
     OpenApiRouter::new()
-        // Get the health status of the service
-        .route("/healthcheck", get(status))
+        // Liveness probe: is the process alive?
+        .route("/healthz/live", get(liveness))
+        // Readiness probe: is the service ready to serve traffic?
+        .route("/healthz/ready", get(readiness))
         .route("/metrics", get(metrics))
 }

--- a/crates/api/src/status/mod.rs
+++ b/crates/api/src/status/mod.rs
@@ -19,9 +19,7 @@ async fn liveness() -> (StatusCode, Json<APIResponse>) {
 /// Readiness probe — confirms the service can handle traffic.
 /// k8s removes the pod from the load balancer (but does NOT restart it) when this fails.
 /// Checks DB connectivity so traffic is only routed when dependencies are reachable.
-async fn readiness(
-    Extension(ctx): Extension<NitteiContext>,
-) -> (StatusCode, Json<APIResponse>) {
+async fn readiness(Extension(ctx): Extension<NitteiContext>) -> (StatusCode, Json<APIResponse>) {
     match ctx.repos.status.check_connection().await {
         Ok(_) => (
             StatusCode::OK,

--- a/crates/api/src/status/mod.rs
+++ b/crates/api/src/status/mod.rs
@@ -61,8 +61,8 @@ async fn metrics() -> (StatusCode, String) {
 pub fn configure_routes() -> OpenApiRouter {
     OpenApiRouter::new()
         // Liveness probe: is the process alive?
-        .route("/healthz/live", get(liveness))
+        .route("/health/live", get(liveness))
         // Readiness probe: is the service ready to serve traffic?
-        .route("/healthz/ready", get(readiness))
+        .route("/health/ready", get(readiness))
         .route("/metrics", get(metrics))
 }


### PR DESCRIPTION
- Split healthcheck endpoint so that we have
  - One specific endpoint for readiness
    - Check DB connection
  - One specific endpoint for liveness
    - Just check if service is alive (but not DB connection)
- Add startup probe in the Helm manifest 

Sources (among others):
- https://kubernetes.io/docs/concepts/workloads/pods/probes/
- https://stackoverflow.com/questions/78690753/kubernetes-liveness-prob-with-database-external-connectivity