### PR TITLE
fix: improve migrate and pg pool setup

### DIFF
--- a/bins/nittei/src/bin/migrate.rs
+++ b/bins/nittei/src/bin/migrate.rs
@@ -7,6 +7,8 @@ async fn main() -> anyhow::Result<()> {
     // Initialize the subscriber for logging & tracing
     init_subscriber()?;
 
+    tracing::info!("Running migrations");
+
     run_migration().await.inspect_err(|e| {
         tracing::error!(error = ?e, "Failed to run migrations");
     })?;

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -17,9 +17,10 @@ pub use repos::{
     SearchEventsParams,
 };
 pub use services::*;
-use sqlx::postgres::PgPoolOptions;
 pub use system::ISys;
 use system::RealSys;
+
+use crate::repos::create_postgres_pool;
 
 /// The context for the application
 /// Contains the repositories, configuration, and system
@@ -61,10 +62,8 @@ pub async fn setup_context() -> anyhow::Result<NitteiContext> {
 /// This is not run by the application itself, but is provided as a utility
 /// Usage is in bins/nittei/src/bin/migrate.rs
 pub async fn run_migration() -> anyhow::Result<()> {
-    let pool = PgPoolOptions::new()
-        .max_connections(5)
-        .connect(nittei_utils::config::APP_CONFIG.pg.database_url.as_str())
-        .await?;
+    let pool =
+        create_postgres_pool(nittei_utils::config::APP_CONFIG.pg.database_url.as_str()).await?;
 
     sqlx::migrate!().run(&pool).await.map_err(|e| e.into())
 }

--- a/crates/infra/src/repos/mod.rs
+++ b/crates/infra/src/repos/mod.rs
@@ -106,7 +106,7 @@ pub async fn create_postgres_pool(connection_string: &str) -> anyhow::Result<Poo
         .await
         .context(format!(
             "Failed to connect to PG url '{}'",
-            remove_password_from_url(connection_string)?
+            redact_password_from_url(connection_string)
         ))?;
 
     info!("[repos] Postgres connection created");
@@ -184,18 +184,13 @@ impl Repos {
     }
 }
 
-/// Remove the password from the connection string
-/// This is a best effort function, so if it fails, we return the connection string as is
-fn remove_password_from_url(connection_string: &str) -> anyhow::Result<String> {
-    let mut url = match url::Url::parse(connection_string) {
-        Ok(url) => url,
-        // If the connection string is not a valid URL, return the connection string as is
-        Err(_) => return Ok(connection_string.to_string()),
+/// Redact the password from the connection string
+fn redact_password_from_url(connection_string: &str) -> String {
+    let Ok(mut url) = url::Url::parse(connection_string) else {
+        return "<unparseable connection string>".to_string();
     };
-
-    // If we have a password, try to remove it
     if url.password().is_some() && url.set_password(Some("*********")).is_err() {
-        return Ok(connection_string.to_string());
+        return "<connection string with unredactable password>".to_string();
     }
-    Ok(url.to_string())
+    url.to_string()
 }

--- a/crates/infra/src/repos/mod.rs
+++ b/crates/infra/src/repos/mod.rs
@@ -97,24 +97,29 @@ pub struct Repos {
     pub user_integrations: Arc<dyn IUserIntegrationRepo>,
 }
 
+pub async fn create_postgres_pool(connection_string: &str) -> anyhow::Result<Pool<Postgres>> {
+    let pool = PgPoolOptions::new()
+        .min_connections(nittei_utils::config::APP_CONFIG.pg.min_connections)
+        .max_connections(nittei_utils::config::APP_CONFIG.pg.max_connections)
+        .acquire_timeout(Duration::from_secs(3)) // Max time to wait for a connection
+        .connect(connection_string)
+        .await
+        .context(format!(
+            "Failed to connect to PG url '{}'",
+            remove_password_from_url(connection_string)?
+        ))?;
+
+    info!("[repos] Postgres connection created");
+
+    Ok(pool)
+}
+
 impl Repos {
     pub async fn create_postgres(connection_string: &str) -> anyhow::Result<Self> {
         // Register metrics
         register_metrics()?;
 
-        info!("[repos] Creating postgres connection");
-        let pool = PgPoolOptions::new()
-            .min_connections(nittei_utils::config::APP_CONFIG.pg.min_connections)
-            .max_connections(nittei_utils::config::APP_CONFIG.pg.max_connections)
-            .acquire_timeout(Duration::from_secs(3)) // Max time to wait for a connection
-            .connect(connection_string)
-            .await
-            .context(format!(
-                "Failed to connect to PG url '{}'",
-                remove_password_from_url(connection_string)?
-            ))?;
-
-        info!("[repos] Postgres connection created");
+        let pool = create_postgres_pool(connection_string).await?;
 
         // Create monitored pool
         let monitored_pool = MonitoredPgPool::new(pool.clone());
@@ -185,7 +190,7 @@ fn remove_password_from_url(connection_string: &str) -> anyhow::Result<String> {
         // If the connection string is not a valid URL, return the connection string as is
         Err(_) => return Ok(connection_string.to_string()),
     };
-    #[allow(clippy::unwrap_used)]
-    url.set_password(Some("*********")).unwrap();
+    // Ignore result as it's only best effort
+    let _ = url.set_password(Some("*********"));
     Ok(url.to_string())
 }

--- a/crates/infra/src/repos/mod.rs
+++ b/crates/infra/src/repos/mod.rs
@@ -98,6 +98,8 @@ pub struct Repos {
 }
 
 pub async fn create_postgres_pool(connection_string: &str) -> anyhow::Result<Pool<Postgres>> {
+    info!("[repos] Creating postgres connection");
+
     let pool = PgPoolOptions::new()
         .min_connections(nittei_utils::config::APP_CONFIG.pg.min_connections)
         .max_connections(nittei_utils::config::APP_CONFIG.pg.max_connections)

--- a/crates/infra/src/repos/mod.rs
+++ b/crates/infra/src/repos/mod.rs
@@ -184,13 +184,18 @@ impl Repos {
     }
 }
 
+/// Remove the password from the connection string
+/// This is a best effort function, so if it fails, we return the connection string as is
 fn remove_password_from_url(connection_string: &str) -> anyhow::Result<String> {
     let mut url = match url::Url::parse(connection_string) {
         Ok(url) => url,
         // If the connection string is not a valid URL, return the connection string as is
         Err(_) => return Ok(connection_string.to_string()),
     };
-    // Ignore result as it's only best effort
-    let _ = url.set_password(Some("*********"));
+
+    // If we have a password, try to remove it
+    if url.password().is_some() && url.set_password(Some("*********")).is_err() {
+        return Ok(connection_string.to_string());
+    }
     Ok(url.to_string())
 }


### PR DESCRIPTION
- Avoid duplicated code for the creation of the PG pool
- Remove one `unwrap` (app shouldn't crash if we fail to replace password) + avoid leaking it